### PR TITLE
[#3] 사용자 프롬프트 및 디스크 이미지 경로 저장

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
 LLM_API_KEY=sk-your-api-key-here
 LLM_MODEL=gpt-4o
 LLM_BASE_URL=https://api.openai.com/v1
+DATABASE_URL=postgresql+asyncpg://user:password@localhost:5432/agent

--- a/config/mcp_servers.example.json
+++ b/config/mcp_servers.example.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "dissect": {
+      "command": "uv",
+      "args": ["run", "--directory", "/path/to/dissect-mcp", "dissect-mcp"]
+    },
+    "remote_plaso": {
+      "transport": "sse",
+      "url": "http://localhost:8080/sse"
+    }
+  }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,8 @@ dependencies = [
     "pydantic-settings>=2.0",
     "tenacity>=8.0",
     "structlog>=24.0",
+    "sqlalchemy[asyncio]>=2.0",
+    "asyncpg>=0.30.0",
 ]
 
 [project.optional-dependencies]
@@ -29,11 +31,11 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
-packages = ["src/mcp_client", "src/llm_provider", "src/graph", "src/prompts"]
+packages = ["src/mcp_client", "src/llm_provider", "src/graph", "src/prompts", "src/database"]
 sources = ["src"]
 
 [tool.hatch.build.targets.editable]
-packages = ["src/mcp_client", "src/llm_provider", "src/graph", "src/prompts"]
+packages = ["src/mcp_client", "src/llm_provider", "src/graph", "src/prompts", "src/database"]
 sources = ["src"]
 
 [tool.pytest.ini_options]

--- a/scripts/run_agent.py
+++ b/scripts/run_agent.py
@@ -2,19 +2,43 @@
 
 Usage:
     uv run python scripts/run_agent.py
+    uv run python scripts/run_agent.py --verbose
 """
 
 from __future__ import annotations
 
+import argparse
 import asyncio
+import logging
 import sys
 from pathlib import Path
 
+import structlog
+
 from config import LLMProvider, load_settings
+from database.engine import get_engine, init_db
+from disk_image_validator import validate_image_path
 from graph.agent import build_agent_graph, create_initial_state
 from llm_provider.anthropic import AnthropicProvider
 from llm_provider.openai import OpenAIProvider
 from mcp_client.client import MCPClientManager
+
+
+def configure_logging(verbose: bool) -> None:
+    """로그 출력 레벨 설정
+
+    Args:
+        verbose: True면 전체 로그 출력, False면 WARNING 이상만 출력
+    """
+    level = logging.DEBUG if verbose else logging.WARNING
+
+    structlog.configure(
+        wrapper_class=structlog.make_filtering_bound_logger(level),
+    )
+
+    logging.basicConfig(level=level, stream=sys.stderr)
+    logging.getLogger("dissect").setLevel(level)
+    logging.getLogger("mcp").setLevel(level)
 
 
 async def async_input(prompt: str) -> str:
@@ -32,7 +56,7 @@ async def async_input(prompt: str) -> str:
     """
     loop = asyncio.get_event_loop()
     return await loop.run_in_executor(
-        None, lambda: sys.stdin.buffer.readline().decode("utf-8").strip()
+        None, lambda: sys.stdin.readline().strip()
     )
 
 
@@ -50,15 +74,17 @@ def create_llm_provider(settings):
     return AnthropicProvider(settings.llm, api_key=settings.llm_api_key)
 
 
-def print_tools(tools):
+def print_tools(tools, verbose: bool = False):
     """발견된 MCP 도구 목록을 출력
 
     Args:
         tools: 도구 이름을 키로, Tool 객체를 값으로 갖는 딕셔너리
+        verbose: 상세 출력 여부
     """
-    print(f"[MCP] 발견된 도구 {len(tools)}개:")
-    for name, tool in tools.items():
-        print(f"  - {name}: {tool.description or '(설명 없음)'}")
+    print(f"[MCP] 발견된 도구 {len(tools)}개")
+    if verbose:
+        for name, tool in tools.items():
+            print(f"  - {name}: {tool.description or '(설명 없음)'}")
 
     if not tools:
         print("[Warning] 사용 가능한 도구가 없습니다.")
@@ -79,8 +105,54 @@ def extract_last_assistant_message(messages):
     return None
 
 
+async def prompt_disk_image_path() -> tuple[str, str] | None:
+    """디스크 이미지 경로를 사용자로부터 입력받아 검증
+
+    경로가 유효할 때까지 반복 질의하며,
+    quit 입력 시 None을 반환하여 종료 신호 전달
+
+    Returns:
+        (검증된 경로, 형식) 튜플 또는 None (종료 시)
+    """
+    print("분석할 디스크 이미지 경로를 입력하세요. (지원 형식: E01, dd, raw)\n")
+
+    while True:
+        sys.stdout.write("Image path: ")
+        sys.stdout.flush()
+        path_input = await async_input("")
+        if not path_input or path_input.lower() in ("quit", "exit", "q"):
+            return None
+
+        result = validate_image_path(path_input)
+        if result.is_valid:
+            assert result.format is not None
+            cleaned_path = path_input.strip("'\"")
+            return cleaned_path, result.format.value
+
+        print(f"[Error] {result.error_message}")
+        print("다시 입력해주세요.\n")
+
+
+def parse_args() -> argparse.Namespace:
+    """커맨드라인 인자 파싱
+
+    Returns:
+        파싱된 인자
+    """
+    parser = argparse.ArgumentParser(description="포렌식 에이전트 실행")
+    parser.add_argument(
+        "--verbose", "-v",
+        action="store_true",
+        help="시스템 로그 메시지 출력 (기본: 숨김)",
+    )
+    return parser.parse_args()
+
+
 async def main() -> None:
     """에이전트 초기화 및 대화형 루프 실행"""
+    args = parse_args()
+    configure_logging(args.verbose)
+
     config_path = Path(__file__).parent.parent / "config" / "mcp_servers.json"
     settings = load_settings(config_path)
 
@@ -91,16 +163,32 @@ async def main() -> None:
         print("[Error] LLM_API_KEY가 설정되지 않았습니다. .env 파일을 확인하세요.")
         return
 
+    if not settings.database_url:
+        print("[Error] DATABASE_URL이 설정되지 않았습니다. .env 파일을 확인하세요.")
+        return
+
+    db_engine = get_engine(settings.database_url)
+    await init_db(db_engine)
+    print("[DB] 데이터베이스 연결 및 테이블 초기화 완료")
+
     llm = create_llm_provider(settings)
 
     async with MCPClientManager(settings.mcp) as mcp:
         tools = await mcp.list_tools()
-        print_tools(tools)
+        print_tools(tools, verbose=args.verbose)
 
-        graph = build_agent_graph(llm, mcp)
+        graph = build_agent_graph(llm, mcp, db_engine)
 
         print("\n===== Forensic Agent =====")
-        print("디스크 이미지 분석 요청을 입력하세요. (quit으로 종료)\n")
+
+        image_result = await prompt_disk_image_path()
+        if image_result is None:
+            print("종료합니다.")
+            return
+
+        image_path, image_format = image_result
+        print(f"\n[Image] {image_path} (형식: {image_format.upper()}) 등록 완료")
+        print("사건 개요를 입력하세요. (quit으로 종료)\n")
 
         while True:
             sys.stdout.write("You: ")
@@ -110,7 +198,11 @@ async def main() -> None:
                 print("종료합니다.")
                 break
 
-            state = create_initial_state(user_input)
+            state = create_initial_state(
+                user_message=user_input,
+                disk_image_path=image_path,
+                disk_image_format=image_format,
+            )
             try:
                 result = await graph.ainvoke(state)
                 reply = extract_last_assistant_message(result["messages"])
@@ -118,6 +210,8 @@ async def main() -> None:
                     print(f"\nAgent: {reply}\n")
             except Exception as e:
                 print(f"\n[Error] {e}\n")
+
+    await db_engine.dispose()
 
 
 if __name__ == "__main__":

--- a/src/config.py
+++ b/src/config.py
@@ -74,9 +74,10 @@ class Settings(BaseSettings):
     """애플리케이션 전체 설정
 
     환경변수 매핑:
-        LLM_API_KEY  → llm_api_key
-        LLM_MODEL    → llm.model (load_settings에서 처리)
-        LLM_BASE_URL → llm.base_url (load_settings에서 처리)
+        LLM_API_KEY    → llm_api_key
+        LLM_MODEL      → llm.model (load_settings에서 처리)
+        LLM_BASE_URL   → llm.base_url (load_settings에서 처리)
+        DATABASE_URL   → database_url
     """
 
     model_config = SettingsConfigDict(
@@ -91,6 +92,7 @@ class Settings(BaseSettings):
     llm_api_key: str = ""
     llm_model: str = ""
     llm_base_url: str = ""
+    database_url: str = ""
 
 
 def _load_mcp_from_json(path: Path) -> MCPConfig:

--- a/src/database/engine.py
+++ b/src/database/engine.py
@@ -1,0 +1,88 @@
+"""비동기 데이터베이스 엔진 및 세션 관리"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager
+
+from sqlalchemy.ext.asyncio import (
+    AsyncEngine,
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+
+from database.models import Base
+
+_engine: AsyncEngine | None = None
+_session_factory: async_sessionmaker[AsyncSession] | None = None
+
+
+def get_engine(database_url: str) -> AsyncEngine:
+    """비동기 SQLAlchemy 엔진 반환
+
+    싱글턴 패턴으로 동일 URL에 대해 하나의 엔진만 생성
+
+    Args:
+        database_url: PostgreSQL 연결 URL
+            (예: postgresql+asyncpg://user:pass@host/db)
+
+    Returns:
+        비동기 SQLAlchemy 엔진
+    """
+    global _engine
+    if _engine is None:
+        _engine = create_async_engine(database_url, echo=False)
+    return _engine
+
+
+def get_session_factory(engine: AsyncEngine) -> async_sessionmaker[AsyncSession]:
+    """비동기 세션 팩토리 반환
+
+    Args:
+        engine: SQLAlchemy 비동기 엔진
+
+    Returns:
+        비동기 세션 팩토리
+    """
+    global _session_factory
+    if _session_factory is None:
+        _session_factory = async_sessionmaker(engine, expire_on_commit=False)
+    return _session_factory
+
+
+@asynccontextmanager
+async def get_session(engine: AsyncEngine) -> AsyncGenerator[AsyncSession, None]:
+    """비동기 세션 컨텍스트 매니저
+
+    Args:
+        engine: SQLAlchemy 비동기 엔진
+
+    Yields:
+        비동기 데이터베이스 세션
+    """
+    factory = get_session_factory(engine)
+    async with factory() as session:
+        yield session
+
+
+async def init_db(engine: AsyncEngine) -> None:
+    """데이터베이스 테이블 초기화
+
+    Base에 등록된 모든 모델의 테이블을 생성
+
+    Args:
+        engine: SQLAlchemy 비동기 엔진
+    """
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+
+def reset_engine() -> None:
+    """엔진 및 세션 팩토리 초기화
+
+    테스트 환경에서 엔진 상태를 리셋할 때 사용
+    """
+    global _engine, _session_factory
+    _engine = None
+    _session_factory = None

--- a/src/database/models.py
+++ b/src/database/models.py
@@ -1,0 +1,40 @@
+"""포렌식 케이스 SQLAlchemy 모델"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import DateTime, String, Text, func
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
+
+
+class Base(DeclarativeBase):
+    """SQLAlchemy 선언적 베이스 클래스"""
+
+
+class Case(Base):
+    """포렌식 분석 케이스
+
+    사용자가 입력한 프롬프트 원문과 디스크 이미지 경로를 저장
+
+    Attributes:
+        id: 케이스 고유 식별자 (자동 증가)
+        user_prompt: 사용자 입력 프롬프트 원문
+        disk_image_path: 디스크 이미지 파일 경로
+        disk_image_format: 검증된 이미지 형식 (e01, dd, raw)
+        created_at: 케이스 생성 시각
+    """
+
+    __tablename__ = "agent"
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    user_prompt: Mapped[str] = mapped_column(Text, nullable=False)
+    disk_image_path: Mapped[str] = mapped_column(String(1024), nullable=False)
+    disk_image_format: Mapped[str] = mapped_column(String(10), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+
+    def __repr__(self) -> str:
+        """케이스 문자열 표현"""
+        return f"<Case(id={self.id}, format={self.disk_image_format})>"

--- a/src/database/repository.py
+++ b/src/database/repository.py
@@ -1,0 +1,64 @@
+"""포렌식 케이스 데이터 액세스 레이어"""
+
+from __future__ import annotations
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from database.models import Case
+
+
+async def create_case(
+    session: AsyncSession,
+    user_prompt: str,
+    disk_image_path: str,
+    disk_image_format: str,
+) -> Case:
+    """새 포렌식 케이스 생성
+
+    Args:
+        session: 비동기 DB 세션
+        user_prompt: 사용자 입력 프롬프트 원문
+        disk_image_path: 검증된 디스크 이미지 경로
+        disk_image_format: 검증된 이미지 형식
+
+    Returns:
+        생성된 Case 인스턴스
+    """
+    case = Case(
+        user_prompt=user_prompt,
+        disk_image_path=disk_image_path,
+        disk_image_format=disk_image_format,
+    )
+    session.add(case)
+    await session.commit()
+    await session.refresh(case)
+    return case
+
+
+async def get_case(session: AsyncSession, case_id: int) -> Case | None:
+    """케이스 ID로 조회
+
+    Args:
+        session: 비동기 DB 세션
+        case_id: 조회할 케이스 ID
+
+    Returns:
+        케이스 인스턴스 또는 None
+    """
+    return await session.get(Case, case_id)
+
+
+async def list_cases(session: AsyncSession) -> list[Case]:
+    """전체 케이스 목록 조회
+
+    Args:
+        session: 비동기 DB 세션
+
+    Returns:
+        케이스 목록 (생성일 내림차순)
+    """
+    result = await session.execute(
+        select(Case).order_by(Case.created_at.desc())
+    )
+    return list(result.scalars().all())

--- a/src/disk_image_validator.py
+++ b/src/disk_image_validator.py
@@ -1,0 +1,122 @@
+"""디스크 이미지 경로 및 형식 검증"""
+
+from __future__ import annotations
+
+import os
+from enum import Enum
+from pathlib import Path
+
+from pydantic import BaseModel
+
+
+class DiskImageFormat(str, Enum):
+    """지원 디스크 이미지 형식"""
+
+    E01 = "e01"
+    DD = "dd"
+    RAW = "raw"
+
+
+EXTENSION_FORMAT_MAP: dict[str, DiskImageFormat] = {
+    ".e01": DiskImageFormat.E01,
+    ".dd": DiskImageFormat.DD,
+    ".raw": DiskImageFormat.RAW,
+    ".img": DiskImageFormat.RAW,
+    ".001": DiskImageFormat.RAW,
+}
+
+
+class ImageValidationResult(BaseModel):
+    """디스크 이미지 유효성 검증 결과
+
+    Attributes:
+        is_valid: 검증 통과 여부
+        format: 감지된 이미지 형식 (유효 시)
+        error_message: 오류 메시지 (실패 시)
+        error_code: 오류 코드 (실패 시)
+    """
+
+    is_valid: bool
+    format: DiskImageFormat | None = None
+    error_message: str | None = None
+    error_code: str | None = None
+
+
+def _check_path_exists(path: Path) -> str | None:
+    """경로 존재 여부 확인
+
+    Args:
+        path: 검사할 파일 경로
+
+    Returns:
+        오류 메시지 (문제 없으면 None)
+    """
+    if not path.exists():
+        return f"지정된 경로에 파일이 존재하지 않습니다: {path}"
+    if not path.is_file():
+        return f"지정된 경로가 파일이 아닙니다: {path}"
+    return None
+
+
+def _check_access_permission(path: Path) -> str | None:
+    """읽기 권한 확인
+
+    Args:
+        path: 검사할 파일 경로
+
+    Returns:
+        오류 메시지 (문제 없으면 None)
+    """
+    if not os.access(path, os.R_OK):
+        return f"파일 접근 권한이 없습니다: {path}"
+    return None
+
+
+def _detect_format(path: Path) -> DiskImageFormat | None:
+    """확장자 기반 디스크 이미지 형식 감지
+
+    Args:
+        path: 디스크 이미지 파일 경로
+
+    Returns:
+        감지된 형식 (미지원 시 None)
+    """
+    suffix = path.suffix.lower()
+    return EXTENSION_FORMAT_MAP.get(suffix)
+
+
+def validate_image_path(path: str | Path) -> ImageValidationResult:
+    """디스크 이미지 경로 및 형식 검증
+
+    경로 존재, 파일 여부, 읽기 권한, 지원 형식을 순차 검증
+
+    Args:
+        path: 디스크 이미지 파일 경로
+
+    Returns:
+        검증 결과
+    """
+    path = Path(str(path).strip("'\""))
+
+    error = _check_path_exists(path)
+    if error:
+        code = "NOT_A_FILE" if path.exists() else "PATH_NOT_FOUND"
+        return ImageValidationResult(
+            is_valid=False, error_message=error, error_code=code
+        )
+
+    error = _check_access_permission(path)
+    if error:
+        return ImageValidationResult(
+            is_valid=False, error_message=error, error_code="ACCESS_DENIED"
+        )
+
+    fmt = _detect_format(path)
+    if fmt is None:
+        return ImageValidationResult(
+            is_valid=False,
+            error_message=f"미지원 형식입니다. 지원 형식: E01, dd, raw ({path.suffix})",
+            error_code="UNSUPPORTED_FORMAT",
+        )
+
+    return ImageValidationResult(is_valid=True, format=fmt)

--- a/src/graph/agent.py
+++ b/src/graph/agent.py
@@ -2,13 +2,17 @@
 
 from __future__ import annotations
 
+import json
 from dataclasses import asdict
 from functools import partial
 from typing import Any
 
 import structlog
 from langgraph.graph import END, START, StateGraph
+from sqlalchemy.ext.asyncio import AsyncEngine
 
+from database.engine import get_session
+from database.repository import create_case
 from graph.state import AgentState
 from llm_provider.anthropic import AnthropicProvider
 from llm_provider.base import BaseLLMProvider, ToolResult
@@ -23,6 +27,36 @@ from prompts.system import build_system_prompt
 logger = structlog.get_logger()
 
 MAX_ITERATIONS = 20
+
+
+def _serialize_tool_calls(
+    tool_calls: list[Any], llm: BaseLLMProvider
+) -> list[dict[str, Any]]:
+    """프로바이더별 tool_calls 메시지 직렬화
+
+    OpenAI는 type/function 중첩 구조, Anthropic은 플랫 구조
+
+    Args:
+        tool_calls: ToolCall 객체 목록
+        llm: LLM 프로바이더 인스턴스
+
+    Returns:
+        직렬화된 tool_calls 목록
+    """
+    if isinstance(llm, AnthropicProvider):
+        return [asdict(tc) for tc in tool_calls]
+
+    return [
+        {
+            "id": tc.id,
+            "type": "function",
+            "function": {
+                "name": tc.name,
+                "arguments": json.dumps(tc.arguments),
+            },
+        }
+        for tc in tool_calls
+    ]
 
 
 async def llm_node(
@@ -51,7 +85,8 @@ async def llm_node(
     }
 
     if response.tool_calls:
-        assistant_message["tool_calls"] = [asdict(tc) for tc in response.tool_calls]
+        serialized = _serialize_tool_calls(response.tool_calls, llm)
+        assistant_message["tool_calls"] = serialized
         return {
             "messages": [assistant_message],
             "pending_tool_calls": [asdict(tc) for tc in response.tool_calls],
@@ -90,16 +125,100 @@ async def tool_node(
             )
         )
 
-    tool_results_message: dict[str, Any] = {
-        "role": "user",
-        "content": [llm.format_tool_result(r) for r in results],
-    }
+    if isinstance(llm, AnthropicProvider):
+        tool_messages: list[dict[str, Any]] = [
+            {
+                "role": "user",
+                "content": [llm.format_tool_result(r) for r in results],
+            }
+        ]
+    else:
+        tool_messages = [llm.format_tool_result(r) for r in results]
 
     return {
-        "messages": [tool_results_message],
+        "messages": tool_messages,
         "pending_tool_calls": [],
         "iteration_count": state["iteration_count"] + 1,
     }
+
+
+async def intake_node(
+    state: AgentState,
+    *,
+    db_engine: AsyncEngine,
+) -> dict[str, Any]:
+    """사건 정보 수신 및 디스크 이미지 등록
+
+    state에 사전 설정된 디스크 이미지 경로와 사용자 프롬프트를
+    DB에 저장하고 분석 단계로 전환
+
+    Args:
+        state: 현재 에이전트 상태
+        db_engine: SQLAlchemy 비동기 엔진
+
+    Returns:
+        상태 업데이트 딕셔너리
+    """
+    last_message = state["messages"][-1]
+    user_text = last_message.get("content", "")
+    image_path = state.get("disk_image_path") or ""
+    fmt = state.get("disk_image_format") or ""
+
+    if not image_path or not fmt:
+        logger.warning("no_image_path_in_state")
+        return {
+            "messages": [
+                {
+                    "role": "assistant",
+                    "content": "디스크 이미지 경로가 설정되지 않았습니다.",
+                }
+            ],
+        }
+
+    async with get_session(db_engine) as session:
+        case = await create_case(
+            session=session,
+            user_prompt=user_text,
+            disk_image_path=image_path,
+            disk_image_format=fmt,
+        )
+        case_id = case.id
+
+    logger.info(
+        "case_created",
+        case_id=case_id,
+        image_path=image_path,
+        image_format=fmt,
+    )
+
+    return {
+        "messages": [
+            {
+                "role": "assistant",
+                "content": f"케이스가 등록되었습니다 (ID: {case_id}). "
+                f"디스크 이미지: {image_path} (형식: {fmt.upper()}). "
+                f"분석을 시작합니다.",
+            }
+        ],
+        "case_id": case_id,
+        "phase": "analysis",
+    }
+
+
+def intake_router(state: AgentState) -> str:
+    """intake 단계 라우팅
+
+    디스크 이미지 검증 성공 시 분석 단계로, 실패 시 종료(사용자 재입력 대기)
+
+    Args:
+        state: 현재 에이전트 상태
+
+    Returns:
+        다음 노드 이름 ("llm" 또는 "end")
+    """
+    if state.get("phase") == "analysis" and state.get("case_id") is not None:
+        return "llm"
+    return "end"
 
 
 def should_continue(state: AgentState) -> str:
@@ -112,20 +231,32 @@ def should_continue(state: AgentState) -> str:
 def build_agent_graph(
     llm: BaseLLMProvider,
     mcp: MCPClientManager,
+    db_engine: AsyncEngine,
 ) -> Any:
     """포렌식 에이전트 LangGraph 구성 및 컴파일
 
-    기본 ReAct 루프:
-        START → llm → [조건부] → tools → llm → ... → END
+    그래프 토폴로지:
+        START → intake → [intake_router] → END (검증 실패)
+                                         → llm (검증 성공)
+        llm → [should_continue] → tools → llm → ... → END
 
-    향후 PR에서 HITL 승인 노드 삽입 예정
+    Args:
+        llm: LLM 프로바이더 인스턴스
+        mcp: MCP 클라이언트 매니저
+        db_engine: SQLAlchemy 비동기 엔진
     """
     graph = StateGraph(AgentState)
 
+    graph.add_node("intake", partial(intake_node, db_engine=db_engine))
     graph.add_node("llm", partial(llm_node, llm=llm, mcp=mcp))
     graph.add_node("tools", partial(tool_node, llm=llm, mcp=mcp))
 
-    graph.add_edge(START, "llm")
+    graph.add_edge(START, "intake")
+    graph.add_conditional_edges(
+        "intake",
+        intake_router,
+        {"llm": "llm", "end": END},
+    )
     graph.add_conditional_edges(
         "llm",
         should_continue,
@@ -136,12 +267,28 @@ def build_agent_graph(
     return graph.compile()
 
 
-def create_initial_state(user_message: str) -> AgentState:
-    """사용자 메시지 기반 초기 에이전트 상태 생성"""
+def create_initial_state(
+    user_message: str,
+    disk_image_path: str | None = None,
+    disk_image_format: str | None = None,
+) -> AgentState:
+    """사용자 메시지 기반 초기 에이전트 상태 생성
+
+    Args:
+        user_message: 사용자 입력 메시지
+        disk_image_path: 사전 검증된 디스크 이미지 경로
+        disk_image_format: 디스크 이미지 형식 (e01, dd, raw)
+
+    Returns:
+        초기 에이전트 상태
+    """
     return AgentState(
         messages=[{"role": "user", "content": user_message}],
         tools={},
         pending_tool_calls=[],
         iteration_count=0,
-        phase="initial",
+        phase="intake",
+        case_id=None,
+        disk_image_path=disk_image_path,
+        disk_image_format=disk_image_format,
     )

--- a/src/graph/state.py
+++ b/src/graph/state.py
@@ -27,4 +27,13 @@ class AgentState(TypedDict):
     """현재 에이전트 루프 반복 횟수 (안전 제한용)"""
 
     phase: str
-    """현재 HITL 단계 (향후 사용)"""
+    """현재 HITL 단계 (intake, analysis 등)"""
+
+    case_id: int | None
+    """DB에 저장된 케이스 ID"""
+
+    disk_image_path: str | None
+    """검증된 디스크 이미지 파일 경로"""
+
+    disk_image_format: str | None
+    """검증된 디스크 이미지 형식 (e01, dd, raw)"""

--- a/src/prompts/system.py
+++ b/src/prompts/system.py
@@ -1,0 +1,28 @@
+"""포렌식 도메인 시스템 프롬프트"""
+
+from __future__ import annotations
+
+FORENSIC_SYSTEM_PROMPT = """\
+You are a digital forensics analysis agent specializing in Windows disk image forensics (DFIR).
+
+## Role
+- Analyze Windows disk images (E01, dd, raw formats)
+- Identify and investigate artifacts: registry hives, event logs (EVTX), prefetch, MFT, browser history, USB traces
+- Construct timelines of attacker/user activity
+- Follow forensic best practices: preserve evidence integrity, document chain of custody
+
+## Guidelines
+- ALWAYS use available forensic tools via MCP to examine evidence directly
+- NEVER fabricate or hallucinate findings — only report what tools confirm
+- Cite the specific tool and artifact source for every claim (e.g., [dissect__registry_analyze])
+- When uncertain, state the uncertainty explicitly
+- Maintain deterministic, reproducible analysis (temperature=0)
+
+## Available Tools
+{tool_descriptions}
+"""
+
+
+def build_system_prompt(tool_descriptions: str) -> str:
+    """시스템 프롬프트에 도구 설명 주입"""
+    return FORENSIC_SYSTEM_PROMPT.format(tool_descriptions=tool_descriptions)


### PR DESCRIPTION
## 연관된 이슈
Close #3

## Summary
사용자 프롬프트와 디스크 이미지 경로를 입력받아 검증 후 PostgreSQL에 저장하는 입력 파이프라인 구현

## Description
  **1. 디스크 이미지 경로/형식 검증 (src/disk_image_validator.py)**
  - 경로 존재 여부, 파일 여부, 읽기 권한을 순차 검증
  - 확장자 기반 형식 감지 (E01, dd, raw, img, 001)
  - 4가지 에러 코드 (PATH_NOT_FOUND, NOT_A_FILE, ACCESS_DENIED, UNSUPPORTED_FORMAT)와 한글 오류 메시지 반환

  **2. PostgreSQL 케이스 저장 레이어 (src/database/)**
  - models.py: Case SQLAlchemy 모델 (user_prompt, disk_image_path, disk_image_format, created_at)
  - repository.py: Case CRUD (create, get, list)
  - 관련 의존성 추가: sqlalchemy[asyncio]>=2.0, asyncpg>=0.30.0
  - 추후 ERD 확정 후 개선 예정 

  **3. intake 노드 및 그래프 토폴로지 변경 (src/graph/agent.py)**
  - intake_node: state의 디스크 이미지 경로와 사용자 프롬프트를 DB에 저장하고 분석 단계로 전환
  - intake_router: 등록 성공 시 llm 노드로, 실패 시 end로 라우팅
  - 그래프 흐름: START → intake → [intake_router] → llm/END

  **4. 실행 스크립트 개선 (scripts/run_agent.py)**
  - 이미지 경로를 채팅과 분리하여 별도 입력 단계로 수신
  - `--verbose` / `-v` 옵션 추가: 기본 실행 시 structlog/dissect/MCP 로그 숨김, 필요 시 전체 출력
  - sys.stdin.readline() 사용으로 한글 경로 입력 인코딩 문제 해결

  **5. 기타**
  - src/config.py: Settings에 database_url 필드 추가 (환경변수 DATABASE_URL에서 로드)
  - src/prompts/system.py, config/mcp_servers.example.json: 이전 PR에서 누락된 시스템 프롬프트와 mcp server 관리용 설정 파일 추가


<img width="1337" height="880" alt="image" src="https://github.com/user-attachments/assets/94305899-70c4-4165-9be8-1d58f6c8460c" />

<img width="1337" height="880" alt="image" src="https://github.com/user-attachments/assets/0084cae7-4a33-4177-85fc-9a97f400da7b" />
