### PR TITLE
[#8] 도구 간 데이터 매핑 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "structlog>=24.0",
     "sqlalchemy[asyncio]>=2.0",
     "asyncpg>=0.30.0",
+    "aiosqlite>=0.20.0",
 ]
 
 [project.optional-dependencies]

--- a/src/graph/agent.py
+++ b/src/graph/agent.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 from dataclasses import asdict
 from functools import partial
 from typing import Any
@@ -22,7 +23,12 @@ from llm_provider.tool_converter import (
     mcp_tools_to_openai,
 )
 from mcp_client.client import MCPClientManager
-from prompts.system import build_planning_prompt, build_strategy_prompt, build_system_prompt
+from prompts.system import (
+    build_planning_prompt,
+    build_step_mapper_prompt,
+    build_strategy_prompt,
+    build_system_prompt,
+)
 
 logger = structlog.get_logger()
 
@@ -400,6 +406,206 @@ def create_planning_state(
         analysis_strategy=strategy,
         analysis_plan="",
         plan_steps=[],
+        current_step_index=0,
+        step_results=[],
+    )
+
+
+# ── 파이프라인 실행 ────────────────────────────────────────
+
+
+def parse_plan_steps(plan_text: str) -> list[dict[str, Any]]:
+    """계획 텍스트에서 JSON 단계 목록 파싱
+
+    build_planning_prompt이 생성한 ```json ... ``` 블록을 추출하여 파싱.
+    파싱 실패 시 빈 리스트 반환.
+
+    Returns:
+        [{index, name, tool, purpose, input_hint}, ...] 형태의 단계 목록
+    """
+    match = re.search(r"```json\s*(\{.*?\})\s*```", plan_text, re.DOTALL)
+    if not match:
+        logger.warning("plan_steps_json_not_found")
+        return []
+    try:
+        data = json.loads(match.group(1))
+        return data.get("steps", [])
+    except json.JSONDecodeError:
+        logger.warning("plan_steps_json_parse_failed")
+        return []
+
+
+def _extract_json_from_text(text: str) -> dict[str, Any]:
+    """LLM 응답 텍스트에서 JSON 객체 추출
+
+    순수 JSON 응답이 아닌 경우(설명 포함)도 처리.
+    추출 실패 시 빈 딕셔너리 반환.
+    """
+    try:
+        return json.loads(text.strip())
+    except json.JSONDecodeError:
+        pass
+    match = re.search(r"\{.*\}", text, re.DOTALL)
+    if match:
+        try:
+            return json.loads(match.group())
+        except json.JSONDecodeError:
+            pass
+    return {}
+
+
+async def step_executor_node(
+    state: AgentState,
+    *,
+    llm: BaseLLMProvider,
+    mcp: MCPClientManager,
+) -> dict[str, Any]:
+    """파이프라인의 현재 단계 실행
+
+    흐름:
+        1. plan_steps[current_step_index]에서 현재 단계 정보 가져옴
+        2. 도구가 'none'이면 MCP 호출 없이 수동 단계로 기록
+        3. 도구가 있으면:
+           a. MCP에서 도구 스키마 조회
+           b. LLM(build_step_mapper_prompt)으로 이전 결과 → 도구 인자 변환
+           c. MCP 도구 호출
+        4. 결과를 step_results에 추가하고 current_step_index 증가
+    """
+    steps = state["plan_steps"]
+    idx = state["current_step_index"]
+    step = steps[idx]
+    tool_key = step.get("tool", "none")
+    previous_results = state["step_results"]
+
+    logger.info("step_executor_start", index=idx, step_name=step.get("name"), tool=tool_key)
+
+    if not tool_key or tool_key.lower() == "none":
+        # 도구 없는 수동 단계 — LLM 호출 없이 목적만 기록
+        output = f"[수동 단계] {step.get('purpose', '')}"
+    else:
+        # 도구 스키마 조회
+        tools = await mcp.list_tools()
+        tool_obj = tools.get(tool_key)
+        tool_schema = (
+            json.dumps(tool_obj.inputSchema, ensure_ascii=False)
+            if tool_obj and hasattr(tool_obj, "inputSchema")
+            else "{}"
+        )
+
+        # 이전 단계들의 계획 정보 (output_hint 포함)
+        previous_steps = steps[:idx]
+
+        # LLM으로 이전 결과 → 현재 도구 인자 매핑
+        # output_hint(계획 시 정의)와 실제 출력을 함께 참조
+        mapper_response = await llm.chat(
+            messages=[{"role": "user", "content": "도구 호출 인자를 생성해주세요."}],
+            tools=None,
+            system=build_step_mapper_prompt(
+                step,
+                previous_steps,
+                previous_results,
+                tool_schema,
+                disk_image_path=state.get("disk_image_path") or "",
+            ),
+        )
+        raw = mapper_response.content if isinstance(mapper_response.content, str) else "{}"
+        arguments = _extract_json_from_text(raw)
+        logger.info("step_mapper_result", tool=tool_key, arguments=arguments)
+
+        # MCP 도구 호출
+        try:
+            call_result = await mcp.call_tool(tool_key, arguments)
+            output = mcp.get_tool_result_text(call_result)
+        except Exception as exc:
+            logger.error("step_tool_call_failed", tool=tool_key, error=str(exc))
+            output = f"Error: {exc}"
+
+    step_result: dict[str, Any] = {
+        "step": step["index"],
+        "name": step.get("name", ""),
+        "tool": tool_key,
+        "output": output,
+    }
+
+    return {
+        "messages": [
+            {
+                "role": "assistant",
+                "content": f"[{step['index']}단계 완료] {step.get('name', '')}: {output[:300]}",
+            }
+        ],
+        "step_results": previous_results + [step_result],
+        "current_step_index": idx + 1,
+    }
+
+
+def pipeline_router(state: AgentState) -> str:
+    """실행할 단계가 남아 있으면 계속, 없으면 종료"""
+    if state["current_step_index"] < len(state["plan_steps"]):
+        return "step"
+    return "end"
+
+
+def build_pipeline_graph(
+    llm: BaseLLMProvider,
+    mcp: MCPClientManager,
+    db_engine: AsyncEngine,
+) -> Any:
+    """파이프라인 실행 그래프
+
+    그래프 토폴로지:
+        START → intake → [intake_router] → END (검증 실패)
+                                         → step (검증 성공)
+        step → [pipeline_router] → step (다음 단계)
+                                 → END (모든 단계 완료)
+
+    plan_steps를 순서대로 실행하며, 각 단계마다 LLM이
+    이전 결과를 현재 도구 인자로 매핑.
+    """
+    graph = StateGraph(AgentState)
+
+    graph.add_node("intake", partial(intake_node, db_engine=db_engine))
+    graph.add_node("step", partial(step_executor_node, llm=llm, mcp=mcp))
+
+    graph.add_edge(START, "intake")
+    graph.add_conditional_edges(
+        "intake",
+        intake_router,
+        {"llm": "step", "end": END},
+    )
+    graph.add_conditional_edges(
+        "step",
+        pipeline_router,
+        {"step": "step", "end": END},
+    )
+
+    return graph.compile()
+
+
+def create_execution_state(
+    user_message: str,
+    analysis_plan: str,
+    plan_steps: list[dict[str, Any]],
+    disk_image_path: str | None = None,
+    disk_image_format: str | None = None,
+) -> AgentState:
+    """파이프라인 실행용 초기 상태 생성
+
+    parse_plan_steps()로 파싱된 plan_steps를 받아
+    step_executor_node가 순서대로 소비할 수 있도록 설정.
+    """
+    return AgentState(
+        messages=[{"role": "user", "content": user_message}],
+        tools={},
+        pending_tool_calls=[],
+        iteration_count=0,
+        phase="intake",
+        case_id=None,
+        disk_image_path=disk_image_path,
+        disk_image_format=disk_image_format,
+        analysis_strategy="",
+        analysis_plan=analysis_plan,
+        plan_steps=plan_steps,
         current_step_index=0,
         step_results=[],
     )

--- a/src/graph/agent.py
+++ b/src/graph/agent.py
@@ -454,6 +454,76 @@ def _extract_json_from_text(text: str) -> dict[str, Any]:
     return {}
 
 
+async def prepare_arguments_with_llm(
+    tool_key: str,
+    step: dict,
+    previous_steps: list[dict],
+    previous_results: list[dict],
+    llm: BaseLLMProvider,
+    mcp: MCPClientManager,
+    disk_image_path: str = "",
+    max_retries: int = 2,
+) -> dict[str, Any]:
+    """이전 도구의 Raw 출력에서 다음 도구 입력 인자를 LLM으로 추출
+
+    흐름:
+        1. Extraction  — 이전 단계 Raw 출력 텍스트 준비
+        2. Reasoning   — LLM이 inputSchema 기반으로 파라미터 추출
+        3. Validation  — required 필드 충족 여부 검증
+        4. 검증 실패 시 오류 메시지와 함께 재시도 (최대 max_retries회)
+
+    Args:
+        tool_key: 호출할 MCP 도구 키 (server__tool 형식)
+        step: 현재 단계 계획 정보 (output_hint, input_hint 포함)
+        previous_steps: 이전 단계들의 계획 정보
+        previous_results: 이전 단계들의 실제 실행 결과 (Raw 텍스트)
+        llm: LLM 프로바이더
+        mcp: MCP 클라이언트 매니저
+        disk_image_path: 분석 대상 디스크 이미지 경로
+        max_retries: 검증 실패 시 최대 재시도 횟수
+
+    Returns:
+        검증을 통과한 tool arguments 딕셔너리
+    """
+    tools = await mcp.list_tools()
+    tool_obj = tools.get(tool_key)
+    schema = tool_obj.inputSchema if tool_obj and hasattr(tool_obj, "inputSchema") else {}
+    tool_schema = json.dumps(schema, ensure_ascii=False)
+    required_fields: list[str] = schema.get("required", [])
+
+    validation_error = ""
+    arguments: dict[str, Any] = {}
+
+    for attempt in range(max_retries):
+        # Reasoning: LLM이 Raw 출력에서 파라미터 추출
+        response = await llm.chat(
+            messages=[{"role": "user", "content": "파라미터를 추출해주세요."}],
+            tools=None,
+            system=build_step_mapper_prompt(
+                step,
+                previous_steps,
+                previous_results,
+                tool_schema,
+                disk_image_path=disk_image_path,
+                validation_error=validation_error,
+            ),
+        )
+        raw = response.content if isinstance(response.content, str) else "{}"
+        arguments = _extract_json_from_text(raw)
+
+        # Validation: required 필드 충족 여부 확인
+        missing = [f for f in required_fields if f not in arguments]
+        if not missing:
+            logger.info("prepare_arguments_success", tool=tool_key, attempt=attempt + 1, arguments=arguments)
+            return arguments
+
+        validation_error = f"필수 파라미터 누락: {missing}. 반드시 포함해야 합니다."
+        logger.warning("prepare_arguments_retry", tool=tool_key, missing=missing, attempt=attempt + 1)
+
+    logger.error("prepare_arguments_failed", tool=tool_key, arguments=arguments)
+    return arguments
+
+
 async def step_executor_node(
     state: AgentState,
     *,
@@ -466,9 +536,8 @@ async def step_executor_node(
         1. plan_steps[current_step_index]에서 현재 단계 정보 가져옴
         2. 도구가 'none'이면 MCP 호출 없이 수동 단계로 기록
         3. 도구가 있으면:
-           a. MCP에서 도구 스키마 조회
-           b. LLM(build_step_mapper_prompt)으로 이전 결과 → 도구 인자 변환
-           c. MCP 도구 호출
+           a. prepare_arguments_with_llm으로 인자 추출 (Extraction → Reasoning → Validation)
+           b. MCP 도구 호출 (Execution)
         4. 결과를 step_results에 추가하고 current_step_index 증가
     """
     steps = state["plan_steps"]
@@ -476,43 +545,26 @@ async def step_executor_node(
     step = steps[idx]
     tool_key = step.get("tool", "none")
     previous_results = state["step_results"]
+    previous_steps = steps[:idx]
 
     logger.info("step_executor_start", index=idx, step_name=step.get("name"), tool=tool_key)
 
     if not tool_key or tool_key.lower() == "none":
-        # 도구 없는 수동 단계 — LLM 호출 없이 목적만 기록
+        # 도구 없는 수동 단계
         output = f"[수동 단계] {step.get('purpose', '')}"
     else:
-        # 도구 스키마 조회
-        tools = await mcp.list_tools()
-        tool_obj = tools.get(tool_key)
-        tool_schema = (
-            json.dumps(tool_obj.inputSchema, ensure_ascii=False)
-            if tool_obj and hasattr(tool_obj, "inputSchema")
-            else "{}"
+        # Extraction → Reasoning → Validation
+        arguments = await prepare_arguments_with_llm(
+            tool_key=tool_key,
+            step=step,
+            previous_steps=previous_steps,
+            previous_results=previous_results,
+            llm=llm,
+            mcp=mcp,
+            disk_image_path=state.get("disk_image_path") or "",
         )
 
-        # 이전 단계들의 계획 정보 (output_hint 포함)
-        previous_steps = steps[:idx]
-
-        # LLM으로 이전 결과 → 현재 도구 인자 매핑
-        # output_hint(계획 시 정의)와 실제 출력을 함께 참조
-        mapper_response = await llm.chat(
-            messages=[{"role": "user", "content": "도구 호출 인자를 생성해주세요."}],
-            tools=None,
-            system=build_step_mapper_prompt(
-                step,
-                previous_steps,
-                previous_results,
-                tool_schema,
-                disk_image_path=state.get("disk_image_path") or "",
-            ),
-        )
-        raw = mapper_response.content if isinstance(mapper_response.content, str) else "{}"
-        arguments = _extract_json_from_text(raw)
-        logger.info("step_mapper_result", tool=tool_key, arguments=arguments)
-
-        # MCP 도구 호출
+        # Execution
         try:
             call_result = await mcp.call_tool(tool_key, arguments)
             output = mcp.get_tool_result_text(call_result)

--- a/src/prompts/system.py
+++ b/src/prompts/system.py
@@ -78,7 +78,92 @@ def build_planning_prompt(strategy: str, tool_summaries: str = "") -> str:
 
 ---
 
-도구가 없는 단계는 MCP 도구란에 "(없음 - 수동)"으로 표기하세요."""
+도구가 없는 단계는 MCP 도구란에 "(없음 - 수동)"으로 표기하세요.
+
+마지막으로 아래 JSON을 반드시 코드 블록 안에 포함하세요:
+
+```json
+{{
+  "steps": [
+    {{
+      "index": 1,
+      "name": "단계명",
+      "tool": "사용할_MCP_도구명 또는 none",
+      "purpose": "목적 한 줄",
+      "output_hint": {{
+        "필드명": "이 단계 실행 후 다음 단계에서 사용할 값 설명"
+      }},
+      "input_hint": "이전 단계의 output_hint 중 어떤 필드를 이 도구의 어떤 파라미터로 넘길지"
+    }}
+  ]
+}}
+```"""
+
+
+def build_step_mapper_prompt(
+    step: dict,
+    previous_steps: list[dict],
+    previous_results: list[dict],
+    tool_schema: str,
+    disk_image_path: str = "",
+) -> str:
+    """단계별 입력 매핑 프롬프트
+
+    이전 단계의 output_hint(계획 시 정의된 출력 필드 설명)와
+    실제 출력(step_results)을 함께 참조하여 현재 도구의 인자를 생성.
+
+    Args:
+        step: 현재 단계 {index, name, tool, purpose, output_hint, input_hint}
+        previous_steps: 이전 단계들의 계획 정보 (output_hint 포함)
+        previous_results: 이전 단계들의 실제 실행 결과
+        tool_schema: 현재 도구의 inputSchema (JSON 문자열)
+        disk_image_path: 분석 대상 디스크 이미지 경로 (path 계열 파라미터에 사용)
+    """
+    # 이전 단계 output_hint + 실제 출력을 함께 구성
+    if previous_steps and previous_results:
+        prev_section = "\n\n".join(
+            f"[{r['step']}단계 - {r['name']}]\n"
+            f"output_hint: {previous_steps[i].get('output_hint', {})}\n"
+            f"실제 출력:\n{r['output']}"
+            for i, r in enumerate(previous_results)
+            if i < len(previous_steps)
+        )
+    elif previous_results:
+        prev_section = "\n\n".join(
+            f"[{r['step']}단계 - {r['name']}]\n실제 출력:\n{r['output']}"
+            for r in previous_results
+        )
+    else:
+        prev_section = "(첫 번째 단계, 이전 결과 없음)"
+
+    current_output_hint = step.get("output_hint", {})
+    input_hint = step.get("input_hint", "")
+
+    image_section = f"\n## 분석 대상 디스크 이미지\n{disk_image_path}" if disk_image_path else ""
+
+    return f"""당신은 디지털 포렌식 분석 AI입니다.
+현재 단계의 MCP 도구를 호출하기 위한 입력 인자를 JSON으로 생성하세요.
+{image_section}
+## 현재 단계
+- 단계: {step['index']}단계 - {step['name']}
+- 도구: {step['tool']}
+- 목적: {step['purpose']}
+- input_hint: {input_hint}
+- 이 단계 완료 후 출력될 필드 (output_hint): {current_output_hint}
+
+## 현재 도구의 입력 파라미터 스키마
+{tool_schema}
+
+## 이전 단계 결과
+{prev_section}
+
+---
+
+규칙:
+- path 계열 파라미터(path, image_path 등)에는 반드시 위의 디스크 이미지 경로를 사용하세요.
+- 나머지 파라미터는 input_hint와 이전 단계의 output_hint를 참고하여 채우세요.
+설명 없이 JSON 객체만 출력합니다.
+예시: {{"path": "/image.dd", "log_path": "C:/Windows/System32/winevt/Logs/Security.evtx"}}"""
 
 
 def build_summary_prompt(step_results: list[dict]) -> str:

--- a/src/prompts/system.py
+++ b/src/prompts/system.py
@@ -106,18 +106,19 @@ def build_step_mapper_prompt(
     previous_results: list[dict],
     tool_schema: str,
     disk_image_path: str = "",
+    validation_error: str = "",
 ) -> str:
-    """단계별 입력 매핑 프롬프트
+    """이전 단계 Raw 출력에서 다음 도구 파라미터를 추출하는 프롬프트
 
-    이전 단계의 output_hint(계획 시 정의된 출력 필드 설명)와
-    실제 출력(step_results)을 함께 참조하여 현재 도구의 인자를 생성.
+    Extraction → Reasoning → Validation 실패 시 재시도 흐름에서 사용.
 
     Args:
         step: 현재 단계 {index, name, tool, purpose, output_hint, input_hint}
         previous_steps: 이전 단계들의 계획 정보 (output_hint 포함)
-        previous_results: 이전 단계들의 실제 실행 결과
+        previous_results: 이전 단계들의 실제 실행 결과 (Raw 텍스트)
         tool_schema: 현재 도구의 inputSchema (JSON 문자열)
-        disk_image_path: 분석 대상 디스크 이미지 경로 (path 계열 파라미터에 사용)
+        disk_image_path: 분석 대상 디스크 이미지 경로
+        validation_error: 직전 시도 검증 실패 메시지 (재시도 시 전달)
     """
     # 이전 단계 output_hint + 실제 출력을 함께 구성
     if previous_steps and previous_results:
@@ -139,29 +140,32 @@ def build_step_mapper_prompt(
     current_output_hint = step.get("output_hint", {})
     input_hint = step.get("input_hint", "")
 
-    image_section = f"\n## 분석 대상 디스크 이미지\n{disk_image_path}" if disk_image_path else ""
+    image_section = f"\n## 분석 대상 디스크 이미지 경로\n{disk_image_path}\n" if disk_image_path else ""
+    retry_section = f"\n## 이전 시도 검증 오류 (반드시 수정)\n{validation_error}\n" if validation_error else ""
 
     return f"""당신은 디지털 포렌식 분석 AI입니다.
-현재 단계의 MCP 도구를 호출하기 위한 입력 인자를 JSON으로 생성하세요.
-{image_section}
-## 현재 단계
+아래 이전 단계의 Raw 출력에서 현재 도구 호출에 필요한 파라미터 값을 추출하세요.
+{image_section}{retry_section}
+## [Extraction] 이전 단계 Raw 출력
+{prev_section}
+
+## [Reasoning] 현재 도구 호출 정보
 - 단계: {step['index']}단계 - {step['name']}
 - 도구: {step['tool']}
 - 목적: {step['purpose']}
 - input_hint: {input_hint}
-- 이 단계 완료 후 출력될 필드 (output_hint): {current_output_hint}
 
-## 현재 도구의 입력 파라미터 스키마
+## [Validation 기준] 현재 도구 inputSchema
 {tool_schema}
-
-## 이전 단계 결과
-{prev_section}
 
 ---
 
-규칙:
-- path 계열 파라미터(path, image_path 등)에는 반드시 위의 디스크 이미지 경로를 사용하세요.
-- 나머지 파라미터는 input_hint와 이전 단계의 output_hint를 참고하여 채우세요.
+추출 규칙:
+1. path / image_path 등 이미지 경로 파라미터 → 반드시 위의 디스크 이미지 경로 사용
+2. 나머지 파라미터 → 이전 단계 Raw 출력과 input_hint를 참고하여 실제 값 추출
+3. schema의 required 필드는 반드시 포함
+4. 값을 찾을 수 없는 선택 파라미터는 생략
+
 설명 없이 JSON 객체만 출력합니다.
 예시: {{"path": "/image.dd", "log_path": "C:/Windows/System32/winevt/Logs/Security.evtx"}}"""
 


### PR DESCRIPTION
## 연관된 이슈
Close #8 
 ## Summary
  이전 MCP 도구의 Raw 텍스트 출력을 다음 도구의 inputSchema에 LLM이 자동 매핑하는 파이프라인 실행 로직을 구현. 
계획 수립 시 정의한 output_hint를 보조 힌트로 활용.

  ## Description

  ### prepare_arguments_with_llm (src/graph/agent.py)
  핵심 매핑 로직. 이전 도구의 실제 실행 결과(Raw 텍스트)와 다음 도구의 inputSchema를 LLM에 함께 전달하면, LLM이 텍스트에서 필요한 값을 찾아 인자를 구성합니다.
  - 입력 ① 이전 단계 Raw 텍스트 출력 → LLM이 직접 파싱
  - 입력 ② 다음 도구 inputSchema     → 추출해야 할 파라미터 구조 정의
  - 입력 ③ output_hint (보조)        → 계획 수립 시 정의한 주목할 필드 힌트
  - 입력 ④ disk_image_path           → path 계열 파라미터에 직접 주입

  ### 파이프라인 그래프 (src/graph/agent.py)
  - `parse_plan_steps()` — 계획 JSON 블록에서 단계 목록 추출
  - `step_executor_node` — 단계별 순차 실행 및 결과 누적
  - `build_pipeline_graph()` — LangGraph StateGraph 조립