### PR TITLE
[#9] AI 요약 결과 생성 및 보고서 작성

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "sqlalchemy[asyncio]>=2.0",
     "asyncpg>=0.30.0",
     "aiosqlite>=0.20.0",
+    "python-docx>=1.1.0",
 ]
 
 [project.optional-dependencies]

--- a/scripts/run_agent.py
+++ b/scripts/run_agent.py
@@ -16,7 +16,11 @@ import argparse
 import asyncio
 import logging
 import sys
+from datetime import datetime
 from pathlib import Path
+
+from docx import Document
+from docx.shared import Pt
 
 import structlog
 
@@ -25,10 +29,13 @@ from database.engine import get_engine, init_db
 from disk_image_validator import validate_image_path
 from graph.agent import (
     build_agent_graph,
+    build_pipeline_graph,
     build_planning_graph,
     build_strategy_graph,
+    create_execution_state,
     create_initial_state,
     create_planning_state,
+    parse_plan_steps,
 )
 from llm_provider.base import BaseLLMProvider
 from llm_provider.anthropic import AnthropicProvider
@@ -268,6 +275,44 @@ async def generate_report(
     return response.content if isinstance(response.content, str) else ""
 
 
+def save_report(report: str, output_dir: Path | None = None) -> Path:
+    """보고서를 docs 디렉터리에 Word(.docx) 파일로 저장
+
+    파일명: report_YYYYMMDD_HHMMSS.docx
+    output_dir 미지정 시 프로젝트 루트의 docs/ 사용.
+
+    마크다운 헤더(# / ##)는 Word Heading 스타일로,
+    나머지 줄은 Normal 단락으로 변환.
+
+    Returns:
+        저장된 파일 경로
+    """
+    if output_dir is None:
+        output_dir = Path(__file__).parent.parent / "docs"
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    doc = Document()
+
+    for line in report.splitlines():
+        if line.startswith("# "):
+            doc.add_heading(line[2:].strip(), level=1)
+        elif line.startswith("## "):
+            doc.add_heading(line[3:].strip(), level=2)
+        elif line.startswith("### "):
+            doc.add_heading(line[4:].strip(), level=3)
+        elif line.strip() == "":
+            doc.add_paragraph()
+        else:
+            p = doc.add_paragraph(line.strip())
+            for run in p.runs:
+                run.font.size = Pt(11)
+
+    filename = f"report_{datetime.now().strftime('%Y%m%d_%H%M%S')}.docx"
+    file_path = output_dir / filename
+    doc.save(str(file_path))
+    return file_path
+
+
 # ── 메인 ─────────────────────────────────────────────────
 
 def parse_args() -> argparse.Namespace:
@@ -327,6 +372,7 @@ async def main() -> None:
         print_tools(tools, verbose=args.verbose)
 
         agent_graph = build_agent_graph(llm, mcp, db_engine)
+        pipeline_graph = build_pipeline_graph(llm, mcp, db_engine)
 
         print("\n===== Forensic Agent =====")
 
@@ -351,22 +397,75 @@ async def main() -> None:
                 # ── 1단계: 전략 수립 (HITL) ──────────────────────
                 strategy = await run_strategy_hitl(strategy_graph, user_input)
 
-                # ── 2단계: 계획 수립 (HITL) ──────────────────────
-                analysis_plan = await run_planning_hitl(
-                    planning_graph, user_input, strategy, tools
-                )
+                # ── 분석 반복 루프 (계획 → 실행 → 요약 → 게이트) ──
+                accumulated_results: list[dict] = []
+                planning_context = user_input  # 추가 분석 시 요청 내용을 덧붙여 갱신
 
-                # 계획 확정 후 다음 사건 입력으로 이동
-                print("\n계획이 확정되었습니다. 새 사건을 입력하거나 quit으로 종료하세요.")
+                while True:
+                    # 2단계: 계획 수립 (HITL)
+                    analysis_plan = await run_planning_hitl(
+                        planning_graph,
+                        planning_context,
+                        strategy,
+                        tools,
+                        accumulated_results or None,
+                    )
 
-                # TODO: 에이전트 실행 단계 추가 예정
-                # exec_state = create_initial_state(
-                #     user_message=user_input,
-                #     disk_image_path=image_path,
-                #     disk_image_format=image_format,
-                #     analysis_plan=analysis_plan,
-                # )
-                # exec_result = await agent_graph.ainvoke(exec_state)
+                    # 3단계: 파이프라인 실행
+                    plan_steps = parse_plan_steps(analysis_plan)
+                    if not plan_steps:
+                        print("[Warning] 실행 가능한 단계가 없습니다.")
+                        break
+
+                    print(f"\n[3단계] 파이프라인 실행 중... ({len(plan_steps)}단계)")
+                    exec_state = create_execution_state(
+                        user_message=user_input,
+                        analysis_plan=analysis_plan,
+                        plan_steps=plan_steps,
+                        disk_image_path=image_path,
+                        disk_image_format=image_format,
+                    )
+                    exec_result = await pipeline_graph.ainvoke(exec_state)
+                    step_results: list[dict] = exec_result.get("step_results", [])
+                    accumulated_results.extend(step_results)
+
+                    # 결과 요약 생성 및 출력
+                    print("\n[4단계] 결과 요약 중...")
+                    summary = await generate_summary(llm, step_results)
+                    print_section("분석 결과 요약", summary)
+
+                    # 게이트: r=보고서 생성 / a=추가 분석 / q=종료
+                    gate = (
+                        await async_input(
+                            "다음 작업을 선택하세요 (r: 보고서 생성 / a: 추가 분석 / q: 종료) > "
+                        )
+                    ).lower()
+
+                    if gate == "r":
+                        print("\n[5단계] 최종 보고서 작성 중...")
+                        report = await generate_report(
+                            llm, user_input, strategy, accumulated_results
+                        )
+                        print_section("포렌식 분석 보고서", report)
+                        saved_path = save_report(report)
+                        print(f"[보고서 저장] {saved_path}")
+                        break
+                    elif gate == "a":
+                        # 추가 조사할 내용을 입력받아 계획 컨텍스트에 반영
+                        additional = ""
+                        while not additional:
+                            additional = await async_input(
+                                "추가로 조사할 내용을 입력하세요 > "
+                            )
+                            if not additional:
+                                print("[알림] 조사할 내용을 입력해야 합니다.")
+                        planning_context = (
+                            f"{user_input}\n\n[추가 조사 요청]: {additional}"
+                        )
+                        continue
+                    else:
+                        # q 또는 기타
+                        break
 
             except Exception as e:
                 print(f"\n[Error] {e}\n")


### PR DESCRIPTION
## 연관된 이슈
Close #9 

## Summary
계획 수립 후 파이프라인 실행 → 결과 요약 → 추가 분석 또는 보고서 생성까지 전체 실행 흐름을 연결하고, 보고서를 Word(.docx) 파일로 저장하는 기능을 구현.

## Description
[1단계] 전략 수립 → HITL 승인
  [2단계] 계획 수립 → HITL 승인
  [3단계] 파이프라인 실행 (단계별 MCP 호출 + LLM 매핑)
  [4단계] 결과 요약 출력
    ├─ r → [5단계] 최종 보고서 생성 → docs/ 에 .docx 저장
    ├─ a → 추가 조사할 내용 입력 → 2단계로 복귀 (이전 결과 누적)
    └─ q → 종료

 **파이프라인 실행 연결 (`scripts/run_agent.py`)**

  계획 수립 HITL 승인 후 `parse_plan_steps()`로 단계 목록을 추출하고 `build_pipeline_graph`로 순차 실행. 실행 결과는`accumulated_results`에 누적되어 추가 분석 시 이전 분석 컨텍스트로 재활용됨.

  **추가 분석 루프**

  게이트에서 `a`를 선택하면 추가로 조사할 내용을 직접 입력받아 `planning_context`에 반영한 뒤 계획 수립 단계부터 재실행.
  이전 분석 결과가 `run_planning_hitl`에 전달되므로 LLM이 중복 없이 필요한 부분만 새 계획을 수립함.

  **Word 보고서 저장 (`save_report`)**

  `r` 선택 시 LLM이 생성한 보고서를 `python-docx`로 변환하여 `docs/report_YYYYMMDD_HHMMSS.docx`로 저장.
  마크다운 헤더(`#`, `##`, `###`)는 Word Heading 스타일로, 나머지 본문은 Normal 단락으로 변환.

<img width="1454" height="548" alt="결과 요약" src="https://github.com/user-attachments/assets/6c479f63-5a57-49b2-8934-419c60f6ba3f" />

<img width="1430" height="888" alt="추가 분석" src="https://github.com/user-attachments/assets/89cf8418-1fcc-43ad-85da-28c6f62decb6" />

<img width="1436" height="1382" alt="보고서 생성" src="https://github.com/user-attachments/assets/9cd8dc8c-e421-4661-923a-6d0aecbe5030" />
