### PR TITLE
[#32] 분석 전략 및 계획 단계 중 이전 분석 내용 참조(RAG) 구현

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,8 @@ dependencies = [
     "asyncpg>=0.30.0",
     "aiosqlite>=0.20.0",
     "python-docx>=1.1.0",
+    "pgvector>=0.3.0",
+    "sentence-transformers>=3.0.0",
 ]
 
 [project.optional-dependencies]

--- a/scripts/rag_manage.py
+++ b/scripts/rag_manage.py
@@ -275,7 +275,8 @@ async def cmd_delete_all(engine) -> None:
 
 async def main() -> None:
     """메인 루프"""
-    settings = load_settings()
+    config_path = Path(__file__).parent.parent / "config" / "mcp_servers.json"
+    settings = load_settings(config_path)
     engine = get_engine(settings.database_url)
     await init_db(engine)
 

--- a/scripts/rag_manage.py
+++ b/scripts/rag_manage.py
@@ -1,0 +1,322 @@
+"""RAG 데이터 관리 인터랙티브 CLI
+
+Usage:
+    python scripts/rag_manage.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from sqlalchemy import select, delete, func
+
+from config import load_settings
+from database.engine import get_engine, init_db, get_session
+from database.models import CaseEmbedding
+from rag.embedding import Embedder
+from rag.pgvector_store import PgVectorStore
+from rag.service import RAGService
+from rag.types import RAGQuery
+
+DIM = "\033[2m"
+BOLD = "\033[1m"
+RESET = "\033[0m"
+GREEN = "\033[32m"
+YELLOW = "\033[33m"
+BLUE = "\033[34m"
+CYAN = "\033[36m"
+
+
+def print_header() -> None:
+    """타이틀 헤더 출력"""
+    print(f"\n{BOLD}{'=' * 50}")
+    print(f"  RAG 데이터 관리")
+    print(f"{'=' * 50}{RESET}\n")
+
+
+def print_menu() -> None:
+    """메인 메뉴 출력"""
+    print(f"  {BOLD}1{RESET}. 문서 목록 조회")
+    print(f"  {BOLD}2{RESET}. 문서 상세 조회")
+    print(f"  {BOLD}3{RESET}. 유사 문서 검색")
+    print(f"  {BOLD}4{RESET}. 문서 추가")
+    print(f"  {BOLD}5{RESET}. 문서 삭제")
+    print(f"  {BOLD}6{RESET}. 전체 삭제")
+    print(f"  {BOLD}q{RESET}. 종료\n")
+
+
+def prompt_phase(required: bool = False) -> str | None:
+    """phase 선택 프롬프트
+
+    Args:
+        required: 필수 입력 여부
+
+    Returns:
+        선택된 phase 문자열 또는 None
+    """
+    print(f"  {DIM}1) strategy  2) planning  3) execution  4) 전체{RESET}")
+    while True:
+        choice = input(f"  phase 선택 > ").strip()
+        mapping = {"1": "strategy", "2": "planning", "3": "execution", "4": None, "": None}
+        if choice in mapping:
+            result = mapping[choice]
+            if required and result is None:
+                print(f"  {YELLOW}phase를 선택해야 합니다.{RESET}")
+                continue
+            return result
+        print(f"  {YELLOW}1~4 중 선택하세요.{RESET}")
+
+
+async def cmd_list(engine) -> None:
+    """저장된 RAG 문서 목록 조회"""
+    print(f"\n{CYAN}[문서 목록 조회]{RESET}")
+    phase = prompt_phase()
+
+    async with get_session(engine) as session:
+        stmt = select(
+            CaseEmbedding.id,
+            CaseEmbedding.case_id,
+            CaseEmbedding.phase,
+            CaseEmbedding.content,
+            CaseEmbedding.created_at,
+        ).order_by(CaseEmbedding.id)
+
+        if phase:
+            stmt = stmt.where(CaseEmbedding.phase == phase)
+
+        result = await session.execute(stmt)
+        rows = result.all()
+
+    if not rows:
+        print(f"  {DIM}저장된 문서가 없습니다.{RESET}")
+        return
+
+    print(f"\n  {BOLD}{'ID':>4}  {'Case':>5}  {'Phase':<10}  {'Created':<17}  Content{RESET}")
+    print(f"  {'-' * 80}")
+    for row in rows:
+        created = row.created_at.strftime("%Y-%m-%d %H:%M") if row.created_at else ""
+        content_preview = row.content.replace("\n", " ")[:50]
+        case_id = str(row.case_id) if row.case_id else "-"
+        print(f"  {row.id:>4}  {case_id:>5}  {row.phase:<10}  {created:<17}  {content_preview}")
+
+    print(f"\n  {GREEN}총 {len(rows)}건{RESET}")
+
+
+async def cmd_get(engine) -> None:
+    """특정 문서 상세 조회"""
+    print(f"\n{CYAN}[문서 상세 조회]{RESET}")
+    id_input = input("  문서 ID > ").strip()
+    if not id_input.isdigit():
+        print(f"  {YELLOW}유효한 ID를 입력하세요.{RESET}")
+        return
+
+    async with get_session(engine) as session:
+        stmt = select(CaseEmbedding).where(CaseEmbedding.id == int(id_input))
+        result = await session.execute(stmt)
+        doc = result.scalar_one_or_none()
+
+    if not doc:
+        print(f"  {YELLOW}ID {id_input} 문서를 찾을 수 없습니다.{RESET}")
+        return
+
+    print(f"\n  {BOLD}ID{RESET}:       {doc.id}")
+    print(f"  {BOLD}Case ID{RESET}:  {doc.case_id or '-'}")
+    print(f"  {BOLD}Phase{RESET}:    {doc.phase}")
+    print(f"  {BOLD}Created{RESET}:  {doc.created_at}")
+    print(f"  {BOLD}Content{RESET}:")
+    for line in doc.content.split("\n"):
+        print(f"    {line}")
+
+
+async def cmd_search(engine, embedder) -> None:
+    """유사 문서 검색"""
+    print(f"\n{CYAN}[유사 문서 검색]{RESET}")
+    query_text = input("  검색 쿼리 > ").strip()
+    if not query_text:
+        print(f"  {YELLOW}쿼리를 입력하세요.{RESET}")
+        return
+
+    phase = prompt_phase()
+    top_k_input = input(f"  결과 수 {DIM}(기본 5){RESET} > ").strip()
+    top_k = int(top_k_input) if top_k_input.isdigit() else 5
+
+    store = PgVectorStore(engine, embedder)
+    query = RAGQuery(
+        query=query_text,
+        top_k=top_k,
+        filters={"phase": phase} if phase else {},
+    )
+
+    print(f"  {DIM}검색 중...{RESET}", end="", flush=True)
+    results = await store.search(query)
+    print(f"\r  {GREEN}검색 완료{RESET}     ")
+
+    if not results:
+        print(f"  {DIM}검색 결과가 없습니다.{RESET}")
+        return
+
+    print(f"\n  {BOLD}{'#':>2}  {'ID':>4}  {'Case':>5}  {'Phase':<10}  {'Score':<7}  Content{RESET}")
+    print(f"  {'-' * 80}")
+    for i, r in enumerate(results, 1):
+        content_preview = r.content.replace("\n", " ")[:45]
+        score_color = GREEN if r.score >= 0.5 else YELLOW if r.score >= 0.3 else DIM
+        print(
+            f"  {i:>2}  {r.metadata.get('id', '?'):>4}  "
+            f"{r.metadata.get('case_id', '-'):>5}  "
+            f"{r.metadata.get('phase', ''):<10}  "
+            f"{score_color}{r.score:<7.3f}{RESET}  {content_preview}"
+        )
+
+
+async def cmd_add(engine, embedder) -> None:
+    """새 문서 추가"""
+    print(f"\n{CYAN}[문서 추가]{RESET}")
+    phase = prompt_phase(required=True)
+
+    print(f"  {DIM}1) 직접 입력  2) 파일에서 읽기{RESET}")
+    source = input("  입력 방식 > ").strip()
+
+    content = ""
+    if source == "2":
+        file_path = input("  파일 경로 > ").strip()
+        path = Path(file_path)
+        if not path.exists():
+            print(f"  {YELLOW}파일을 찾을 수 없습니다: {file_path}{RESET}")
+            return
+        content = path.read_text(encoding="utf-8").strip()
+        print(f"  {DIM}{len(content)}자 읽음{RESET}")
+    else:
+        print(f"  {DIM}내용을 입력하세요 (빈 줄 입력 시 완료):{RESET}")
+        lines = []
+        while True:
+            line = input("  ")
+            if line == "":
+                break
+            lines.append(line)
+        content = "\n".join(lines)
+
+    if not content:
+        print(f"  {YELLOW}내용이 비어있습니다.{RESET}")
+        return
+
+    case_id_input = input(f"  케이스 ID {DIM}(없으면 Enter){RESET} > ").strip()
+
+    store = PgVectorStore(engine, embedder)
+    metadata: dict[str, str] = {"phase": phase}
+    if case_id_input.isdigit():
+        metadata["case_id"] = case_id_input
+
+    print(f"  {DIM}임베딩 생성 중...{RESET}", end="", flush=True)
+    doc_id = await store.add_document(content=content, metadata=metadata)
+    print(f"\r  {GREEN}문서 추가 완료{RESET} (ID: {doc_id}, phase: {phase}, {len(content)}자)")
+
+
+async def cmd_delete(engine) -> None:
+    """단건 문서 삭제"""
+    print(f"\n{CYAN}[문서 삭제]{RESET}")
+    id_input = input("  삭제할 문서 ID > ").strip()
+    if not id_input.isdigit():
+        print(f"  {YELLOW}유효한 ID를 입력하세요.{RESET}")
+        return
+
+    async with get_session(engine) as session:
+        stmt = select(CaseEmbedding.id, CaseEmbedding.phase, CaseEmbedding.content).where(
+            CaseEmbedding.id == int(id_input)
+        )
+        result = await session.execute(stmt)
+        doc = result.one_or_none()
+
+    if not doc:
+        print(f"  {YELLOW}ID {id_input} 문서를 찾을 수 없습니다.{RESET}")
+        return
+
+    preview = doc.content.replace("\n", " ")[:60]
+    print(f"  대상: [{doc.phase}] {preview}")
+    confirm = input(f"  삭제하시겠습니까? (y/N) > ").strip().lower()
+    if confirm != "y":
+        print(f"  {DIM}취소{RESET}")
+        return
+
+    async with get_session(engine) as session:
+        await session.execute(
+            delete(CaseEmbedding).where(CaseEmbedding.id == int(id_input))
+        )
+        await session.commit()
+    print(f"  {GREEN}삭제 완료{RESET}")
+
+
+async def cmd_delete_all(engine) -> None:
+    """전체 문서 삭제"""
+    print(f"\n{CYAN}[전체 삭제]{RESET}")
+    async with get_session(engine) as session:
+        count_result = await session.execute(
+            select(func.count()).select_from(CaseEmbedding)
+        )
+        count = count_result.scalar()
+
+    if count == 0:
+        print(f"  {DIM}삭제할 문서가 없습니다.{RESET}")
+        return
+
+    confirm = input(f"  {YELLOW}전체 {count}건을 삭제하시겠습니까?{RESET} (y/N) > ").strip().lower()
+    if confirm != "y":
+        print(f"  {DIM}취소{RESET}")
+        return
+
+    async with get_session(engine) as session:
+        await session.execute(delete(CaseEmbedding))
+        await session.commit()
+    print(f"  {GREEN}{count}건 삭제 완료{RESET}")
+
+
+async def main() -> None:
+    """메인 루프"""
+    settings = load_settings()
+    engine = get_engine(settings.database_url)
+    await init_db(engine)
+
+    embedder = None
+
+    def get_embedder() -> Embedder:
+        nonlocal embedder
+        if embedder is None:
+            print(f"  {DIM}임베딩 모델 로드 중...{RESET}", end="", flush=True)
+            embedder = Embedder(settings.rag.embedding_model)
+            print(f"\r  {GREEN}모델 로드 완료{RESET}              ")
+        return embedder
+
+    print_header()
+
+    while True:
+        print_menu()
+        choice = input(f"  선택 > ").strip().lower()
+
+        if choice == "1":
+            await cmd_list(engine)
+        elif choice == "2":
+            await cmd_get(engine)
+        elif choice == "3":
+            await cmd_search(engine, get_embedder())
+        elif choice == "4":
+            await cmd_add(engine, get_embedder())
+        elif choice == "5":
+            await cmd_delete(engine)
+        elif choice == "6":
+            await cmd_delete_all(engine)
+        elif choice in ("q", "quit", "exit"):
+            print("종료합니다.")
+            break
+        else:
+            print(f"  {YELLOW}1~6 또는 q를 입력하세요.{RESET}")
+
+        print()
+
+    await engine.dispose()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/scripts/run_agent.py
+++ b/scripts/run_agent.py
@@ -46,6 +46,9 @@ from llm_provider.anthropic import AnthropicProvider
 from llm_provider.base import BaseLLMProvider
 from llm_provider.openai import OpenAIProvider
 from mcp_client.client import MCPClientManager
+from rag.embedding import Embedder
+from rag.pgvector_store import PgVectorStore
+from rag.service import RAGService
 
 
 DIM = "\033[2m"
@@ -349,7 +352,7 @@ def save_report(
     return docx_path, dfxml_path
 
 
-async def run_strategy_hitl(state, llm) -> dict:
+async def run_strategy_hitl(state, llm, rag_service=None) -> dict:
     """전략 수립 HITL 루프
 
     LLM이 전략을 생성하고 사용자가 승인/수정할 때까지 반복
@@ -360,8 +363,12 @@ async def run_strategy_hitl(state, llm) -> dict:
     while True:
         start = time.time()
         print(f"  {DIM}LLM 호출 중...{RESET}", end="", flush=True)
-        current = await run_strategy(current, llm)
+        current = await run_strategy(current, llm, rag_service=rag_service)
         print(f"\r  {GREEN}전략 생성 완료{RESET} ({_elapsed(start)})")
+
+        rag_ctx = current.get("rag_context", "")
+        if rag_ctx:
+            print(f"\n  {BLUE}[RAG] 유사 사례 컨텍스트가 프롬프트에 주입됨 ({len(rag_ctx)}자){RESET}")
 
         strategy = current.get("analysis_strategy", "")
         print_section("분석 전략 (조사 대상 아티팩트)", strategy)
@@ -390,7 +397,7 @@ async def run_strategy_hitl(state, llm) -> dict:
         print(f"  {DIM}전략 재수립 중...{RESET}")
 
 
-async def run_planning_hitl(state, llm, mcp) -> dict:
+async def run_planning_hitl(state, llm, mcp, rag_service=None) -> dict:
     """계획 수립 HITL 루프
 
     LLM이 계획을 생성하고 사용자가 승인/수정할 때까지 반복
@@ -401,8 +408,12 @@ async def run_planning_hitl(state, llm, mcp) -> dict:
     while True:
         start = time.time()
         print(f"  {DIM}LLM 호출 중...{RESET}", end="", flush=True)
-        current = await run_planning(current, llm, mcp)
+        current = await run_planning(current, llm, mcp, rag_service=rag_service)
         print(f"\r  {GREEN}계획 생성 완료{RESET} ({_elapsed(start)})")
+
+        rag_ctx = current.get("rag_context", "")
+        if rag_ctx:
+            print(f"\n  {BLUE}[RAG] 유사 사례 컨텍스트가 프롬프트에 주입됨 ({len(rag_ctx)}자){RESET}")
 
         plan = current.get("analysis_plan", "")
         steps = current.get("plan_steps", [])
@@ -548,6 +559,19 @@ async def main() -> None:
     await init_db(db_engine)
     print(f"  {BOLD}DB{RESET}:   초기화 완료")
 
+    rag_service = None
+    if settings.rag.enabled:
+        print(f"  {DIM}RAG 임베딩 모델 로드 중...{RESET}", end="", flush=True)
+        embedder = Embedder(model_name=settings.rag.embedding_model)
+        store = PgVectorStore(engine=db_engine, embedder=embedder)
+        await store.ensure_extension()
+        rag_service = RAGService(
+            store=store,
+            top_k=settings.rag.search_top_k,
+            similarity_threshold=settings.rag.similarity_threshold,
+        )
+        print(f"\r  {GREEN}RAG 초기화 완료{RESET} (모델: {settings.rag.embedding_model})")
+
     llm = create_llm_provider(settings, api_choice)
 
     async with MCPClientManager(settings.mcp) as mcp:
@@ -600,7 +624,7 @@ async def main() -> None:
                     print(f"[Cache] 전략 캐시 적용 ({cache_key})")
                     print_section("분석 전략 (캐시)", state.get("analysis_strategy", ""))
                 else:
-                    state = await run_strategy_hitl(state, llm)
+                    state = await run_strategy_hitl(state, llm, rag_service=rag_service)
                     if cache_key:
                         _save_cache(cache_key, "strategy", {
                             "analysis_strategy": state.get("analysis_strategy", ""),
@@ -620,7 +644,7 @@ async def main() -> None:
                         print(f"  → 파싱된 실행 단계: {len(state.get('plan_steps', []))}개")
                         cache_key = ""
                     else:
-                        state = await run_planning_hitl(state, llm, mcp)
+                        state = await run_planning_hitl(state, llm, mcp, rag_service=rag_service)
                         if cache_key:
                             _save_cache(cache_key, "planning", {
                                 "analysis_plan": state.get("analysis_plan", ""),
@@ -636,7 +660,7 @@ async def main() -> None:
 
                     exec_start = time.time()
                     cb = ConsoleExecutionCallback()
-                    state = await run_execution(state, llm, mcp, callback=cb)
+                    state = await run_execution(state, llm, mcp, callback=cb, rag_service=rag_service)
 
                     task_results = state.get("task_results", [])
                     accumulated_results.extend(task_results)

--- a/src/agents/manager/graph.py
+++ b/src/agents/manager/graph.py
@@ -22,6 +22,7 @@ from agents.manager.nodes import (
 from agents.report.graph import build_report_graph, create_report_state
 from llm_provider.base import BaseLLMProvider
 from mcp_client.client import MCPClientManager
+from rag.service import RAGService
 from state.manager import ManagerState
 from state.messages import TaskAssignment, TaskResult
 
@@ -47,18 +48,22 @@ class ExecutionCallback(Protocol):
 async def run_strategy(
     state: ManagerState,
     llm: BaseLLMProvider,
+    rag_service: RAGService | None = None,
 ) -> ManagerState:
     """전략 수립 단계 실행
 
     Args:
         state: Manager 상태 (system_profile 포함)
         llm: LLM 프로바이더
+        rag_service: RAG 서비스 (None이면 RAG 비활성)
 
     Returns:
         analysis_strategy가 채워진 상태
     """
     system_profile = state.get("system_profile") or ""
-    updates = await strategy_node(state, llm=llm, system_profile=system_profile)
+    updates = await strategy_node(
+        state, llm=llm, system_profile=system_profile, rag_service=rag_service
+    )
     return {**state, **updates}
 
 
@@ -66,6 +71,7 @@ async def run_planning(
     state: ManagerState,
     llm: BaseLLMProvider,
     mcp: MCPClientManager,
+    rag_service: RAGService | None = None,
 ) -> ManagerState:
     """계획 수립 단계 실행
 
@@ -73,11 +79,12 @@ async def run_planning(
         state: 전략이 확정된 Manager 상태
         llm: LLM 프로바이더
         mcp: MCP 클라이언트 매니저
+        rag_service: RAG 서비스 (None이면 RAG 비활성)
 
     Returns:
         plan_steps가 채워진 상태
     """
-    updates = await planning_node(state, llm=llm, mcp=mcp)
+    updates = await planning_node(state, llm=llm, mcp=mcp, rag_service=rag_service)
     return {**state, **updates}
 
 
@@ -87,11 +94,13 @@ async def run_execution(
     mcp: MCPClientManager,
     callback: ExecutionCallback | None = None,
     registry: AgentRegistry | None = None,
+    rag_service: RAGService | None = None,
 ) -> ManagerState:
     """Sub-Agent 실행 단계
 
     plan_steps의 각 단계를 순차적으로 Sub-Agent에 동적 dispatch하고 결과 수집.
     AgentRegistry를 통해 MCP 서버명 기반으로 전용/범용 에이전트를 자동 선택.
+    실행 완료 후 RAG 서비스가 활성화되어 있으면 결과를 벡터 저장소에 저장.
 
     Args:
         state: 계획이 확정된 Manager 상태
@@ -99,6 +108,7 @@ async def run_execution(
         mcp: MCP 클라이언트 매니저
         callback: 진행 상황 콜백 (None이면 무시)
         registry: Sub-Agent 레지스트리 (None이면 기본 레지스트리 사용)
+        rag_service: RAG 서비스 (None이면 결과 저장 건너뜀)
 
     Returns:
         task_results가 채워진 상태
@@ -249,6 +259,26 @@ async def run_execution(
 
         i += 1
 
+    if rag_service and state.get("case_id"):
+        results_summary = "\n".join(
+            f"[{r.get('agent_name', '')}] {r.get('output', '')[:300]}"
+            for r in results
+            if r.get("status") == "success"
+        )
+        case_description = ""
+        if state.get("messages"):
+            case_description = state["messages"][0].get("content", "")
+        try:
+            await rag_service.store_case_result(
+                case_id=state["case_id"],
+                strategy=state.get("analysis_strategy", ""),
+                plan=state.get("analysis_plan", ""),
+                results_summary=results_summary,
+                case_description=case_description,
+            )
+        except Exception as exc:
+            logger.warning("rag_store_failed", error=str(exc))
+
     return {
         **state,
         "task_results": results,
@@ -323,4 +353,5 @@ def create_manager_state(
         hitl_pending=False,
         hitl_type="",
         evidence_repository=[],
+        rag_context="",
     )

--- a/src/agents/manager/nodes.py
+++ b/src/agents/manager/nodes.py
@@ -12,6 +12,7 @@ import structlog
 from prompts.manager import build_planning_prompt, build_strategy_prompt
 from llm_provider.base import BaseLLMProvider
 from mcp_client.client import MCPClientManager
+from rag.service import RAGService
 from state.manager import ManagerState
 from state.messages import TaskAssignment
 
@@ -23,6 +24,7 @@ async def strategy_node(
     *,
     llm: BaseLLMProvider,
     system_profile: str = "",
+    rag_service: RAGService | None = None,
 ) -> dict[str, Any]:
     """사용자 사건 입력을 바탕으로 분석 전략 수립
 
@@ -30,22 +32,40 @@ async def strategy_node(
         state: Manager 상태
         llm: LLM 프로바이더
         system_profile: 디스크 이미지 시스템 프로필 (OS 정보 등)
+        rag_service: RAG 서비스 (None이면 RAG 비활성)
     """
     disk_image_format = state.get("disk_image_format", "")
+
+    rag_context = ""
+    if rag_service:
+        user_message = state["messages"][0].get("content", "") if state["messages"] else ""
+        if user_message:
+            results = await rag_service.search_similar_cases(user_message)
+            rag_context = RAGService.format_rag_context(results)
+            if results:
+                logger.info(
+                    "rag_strategy_injected",
+                    hits=len(results),
+                    top_score=results[0].score,
+                    context_length=len(rag_context),
+                )
+
     response = await llm.chat(
         messages=state["messages"],
         tools=None,
         system=build_strategy_prompt(
             disk_image_format=disk_image_format,
             system_profile=system_profile,
+            rag_context=rag_context,
         ),
     )
     strategy_text = response.content if isinstance(response.content, str) else ""
-    logger.info("strategy_created", length=len(strategy_text))
+    logger.info("strategy_created", length=len(strategy_text), rag_hits=bool(rag_context))
 
     return {
         "messages": [{"role": "assistant", "content": response.content}],
         "analysis_strategy": strategy_text,
+        "rag_context": rag_context,
         "phase": "planning",
     }
 
@@ -55,6 +75,7 @@ async def planning_node(
     *,
     llm: BaseLLMProvider,
     mcp: MCPClientManager,
+    rag_service: RAGService | None = None,
 ) -> dict[str, Any]:
     """수립된 전략을 바탕으로 세부 실행 계획 수립
 
@@ -62,9 +83,24 @@ async def planning_node(
         state: Manager 상태
         llm: LLM 프로바이더
         mcp: MCP 클라이언트 매니저 (도구 목록 조회용)
+        rag_service: RAG 서비스 (None이면 RAG 비활성)
     """
     server_names = mcp.connected_servers
     server_list = "\n".join(f"- {name}" for name in server_names) if server_names else ""
+
+    rag_context = ""
+    if rag_service:
+        strategy_text = state.get("analysis_strategy", "")
+        if strategy_text:
+            results = await rag_service.search_similar_plans(strategy_text)
+            rag_context = RAGService.format_rag_context(results)
+            if results:
+                logger.info(
+                    "rag_planning_injected",
+                    hits=len(results),
+                    top_score=results[0].score,
+                    context_length=len(rag_context),
+                )
 
     messages = list(state["messages"])
     if messages and messages[-1].get("role") == "assistant":
@@ -76,16 +112,18 @@ async def planning_node(
         system=build_planning_prompt(
             state.get("analysis_strategy", ""),
             server_list,
+            rag_context=rag_context,
         ),
     )
     plan_text = response.content if isinstance(response.content, str) else ""
     plan_steps = _parse_plan_steps(plan_text)
-    logger.info("plan_created", length=len(plan_text), steps=len(plan_steps))
+    logger.info("plan_created", length=len(plan_text), steps=len(plan_steps), rag_hits=bool(rag_context))
 
     return {
         "messages": [{"role": "assistant", "content": response.content}],
         "analysis_plan": plan_text,
         "plan_steps": plan_steps,
+        "rag_context": rag_context,
         "phase": "execution",
     }
 

--- a/src/config.py
+++ b/src/config.py
@@ -74,6 +74,22 @@ class LLMConfig(BaseModel):
     base_url: str | None = None
 
 
+class RAGConfig(BaseModel):
+    """RAG 벡터스토어 설정
+
+    Attributes:
+        enabled: RAG 기능 활성화 여부
+        embedding_model: 임베딩 모델명 (HuggingFace 모델 ID)
+        search_top_k: 검색 시 반환할 최대 결과 수
+        similarity_threshold: 유사도 필터 임계값 (0.0~1.0)
+    """
+
+    enabled: bool = False
+    embedding_model: str = "BAAI/bge-m3"
+    search_top_k: int = 3
+    similarity_threshold: float = 0.5
+
+
 class Settings(BaseSettings):
     """애플리케이션 전체 설정
 
@@ -90,11 +106,13 @@ class Settings(BaseSettings):
     model_config = SettingsConfigDict(
         env_file=".env",
         env_file_encoding="utf-8",
+        env_nested_delimiter="__",
         extra="ignore",
     )
 
     llm: LLMConfig = Field(default_factory=LLMConfig)
     mcp: MCPConfig = Field(default_factory=MCPConfig)
+    rag: RAGConfig = Field(default_factory=RAGConfig)
 
     llm_api_key: str = ""
     llm_model: str = ""

--- a/src/database/models.py
+++ b/src/database/models.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from datetime import datetime
 
+from pgvector.sqlalchemy import Vector
 from sqlalchemy import DateTime, ForeignKey, Integer, String, Text, func
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
 
@@ -110,3 +111,38 @@ class StepResult(Base):
     def __repr__(self) -> str:
         """단계 결과 문자열 표현"""
         return f"<StepResult(id={self.id}, step={self.step_index}, tool={self.tool_name})>"
+
+
+EMBEDDING_DIMENSION = 1024
+
+
+class CaseEmbedding(Base):
+    """케이스 분석 결과 임베딩 (pgvector)
+
+    과거 분석 사례를 벡터로 저장하여 유사 케이스 RAG 검색에 사용
+
+    Attributes:
+        id: 임베딩 고유 식별자 (자동 증가)
+        case_id: 연관 케이스 ID (FK)
+        phase: 분석 단계 (strategy, planning, execution)
+        content: 임베딩된 원본 텍스트
+        embedding: pgvector 벡터 (1024차원, BGE-M3)
+        created_at: 생성 시각
+    """
+
+    __tablename__ = "case_embedding"
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    case_id: Mapped[int | None] = mapped_column(
+        Integer, ForeignKey("agent.id"), nullable=True
+    )
+    phase: Mapped[str] = mapped_column(String(20), nullable=False)
+    content: Mapped[str] = mapped_column(Text, nullable=False)
+    embedding = mapped_column(Vector(EMBEDDING_DIMENSION), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+
+    def __repr__(self) -> str:
+        """케이스 임베딩 문자열 표현"""
+        return f"<CaseEmbedding(id={self.id}, case_id={self.case_id}, phase={self.phase})>"

--- a/src/prompts/manager.py
+++ b/src/prompts/manager.py
@@ -8,12 +8,17 @@
 from __future__ import annotations
 
 
-def build_strategy_prompt(disk_image_format: str = "", system_profile: str = "") -> str:
+def build_strategy_prompt(
+    disk_image_format: str = "",
+    system_profile: str = "",
+    rag_context: str = "",
+) -> str:
     """사건 정보를 바탕으로 조사할 아티팩트 목록 도출
 
     Args:
         disk_image_format: 디스크 이미지 형식 (e01, dd 등)
         system_profile: 시스템 프로필 정보 (OS, 호스트명 등)
+        rag_context: RAG로 검색된 유사 사례 전략 텍스트
     """
     context_parts = []
     if disk_image_format:
@@ -22,12 +27,21 @@ def build_strategy_prompt(disk_image_format: str = "", system_profile: str = "")
         context_parts.append(f"시스템 정보:\n{system_profile}")
     context_block = "\n".join(context_parts)
 
+    rag_section = ""
+    if rag_context:
+        rag_section = f"""
+[유사 사건 조사 경험 (참고용)]
+아래는 과거 유사 사건에서 사용된 조사 전략입니다. 참고하되 현재 사건에 맞게 판단하세요.
+
+{rag_context}
+"""
+
     return f"""당신은 디지털 포렌식 분석 전문가 AI입니다.
 
 사용자가 제공한 사건 정보를 바탕으로, 이 사건에서 조사해야 할 아티팩트 목록만 작성하세요.
 설명이나 분석 방법은 쓰지 말고, 아티팩트 이름과 조사 이유를 한 줄씩 나열하세요.
 
-{f"[디스크 이미지 정보]{chr(10)}{context_block}{chr(10)}" if context_block else ""}출력 형식 (이 형식만 사용):
+{f"[디스크 이미지 정보]{chr(10)}{context_block}{chr(10)}" if context_block else ""}{rag_section}출력 형식 (이 형식만 사용):
 
 ## 조사 대상 아티팩트
 - [아티팩트명]: [조사 이유 한 줄]
@@ -43,7 +57,11 @@ def build_strategy_prompt(disk_image_format: str = "", system_profile: str = "")
 사건과 관련된 아티팩트만 선별하고, 불필요한 항목은 포함하지 마세요."""
 
 
-def build_planning_prompt(strategy: str, mcp_servers: str = "") -> str:
+def build_planning_prompt(
+    strategy: str,
+    mcp_servers: str = "",
+    rag_context: str = "",
+) -> str:
     """수립된 전략을 바탕으로 세부 실행 계획 수립 프롬프트
 
     각 단계에서 어떤 MCP 서버(= Sub-Agent)를 사용할지만 지정.
@@ -52,7 +70,15 @@ def build_planning_prompt(strategy: str, mcp_servers: str = "") -> str:
     Args:
         strategy: strategy_node가 수립한 분석 전략 텍스트
         mcp_servers: 사용 가능한 MCP 서버 목록 문자열
+        rag_context: RAG로 검색된 유사 사례 실행 계획 텍스트
     """
+    rag_section = ""
+    if rag_context:
+        rag_section = f"""
+[유사 사건의 실행 계획 참고]
+{rag_context}
+"""
+
     return f"""당신은 디지털 포렌식 분석 전문가 AI입니다.
 
 아래 조사 대상 아티팩트 목록을 바탕으로 단계별 실행 계획을 작성하세요.
@@ -64,7 +90,7 @@ def build_planning_prompt(strategy: str, mcp_servers: str = "") -> str:
 
 [사용 가능한 MCP 서버]
 {mcp_servers if mcp_servers else "(연결된 서버 없음)"}
-
+{rag_section}
 ---
 
 **가장 먼저** 아래 JSON을 코드 블록으로 출력하세요. (상세 설명보다 반드시 앞에 위치)

--- a/src/rag/__init__.py
+++ b/src/rag/__init__.py
@@ -1,6 +1,19 @@
-"""RAG(Retrieval-Augmented Generation) 인터페이스 패키지"""
+"""RAG(Retrieval-Augmented Generation) 패키지
+
+pgvector + BGE-M3 기반 포렌식 사례 검색 파이프라인
+"""
 
 from rag.base import BaseVectorStore
+from rag.embedding import Embedder
+from rag.pgvector_store import PgVectorStore
+from rag.service import RAGService
 from rag.types import RAGQuery, RAGResult
 
-__all__ = ["BaseVectorStore", "RAGQuery", "RAGResult"]
+__all__ = [
+    "BaseVectorStore",
+    "Embedder",
+    "PgVectorStore",
+    "RAGQuery",
+    "RAGResult",
+    "RAGService",
+]

--- a/src/rag/embedding.py
+++ b/src/rag/embedding.py
@@ -1,0 +1,100 @@
+"""BGE-M3 임베딩 유틸리티
+
+SentenceTransformer 기반 텍스트 → 벡터 변환.
+동기 라이브러리를 asyncio 환경에서 사용하기 위해
+run_in_executor 패턴으로 async 래핑.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from functools import partial
+from typing import Any
+
+import structlog
+
+logger = structlog.get_logger()
+
+
+class Embedder:
+    """텍스트 임베딩 생성기
+
+    Attributes:
+        model_name: HuggingFace 모델 ID
+        dimension: 출력 벡터 차원 수
+    """
+
+    def __init__(self, model_name: str = "BAAI/bge-m3", preload: bool = True) -> None:
+        """임베딩 모델 초기화
+
+        Args:
+            model_name: HuggingFace 모델 ID
+            preload: True이면 생성 시점에 모델을 즉시 로드
+        """
+        self.model_name = model_name
+        self._model: Any = None
+        self.dimension: int = 1024
+        if preload:
+            self._load_model()
+
+    def _load_model(self) -> Any:
+        """SentenceTransformer 모델 지연 로드
+
+        Returns:
+            로드된 SentenceTransformer 모델 인스턴스
+        """
+        if self._model is None:
+            from sentence_transformers import SentenceTransformer
+
+            self._model = SentenceTransformer(self.model_name)
+            self.dimension = self._model.get_embedding_dimension()
+            logger.info(
+                "embedding_model_loaded",
+                model=self.model_name,
+                dimension=self.dimension,
+            )
+        return self._model
+
+    def _encode_sync(self, texts: list[str]) -> list[list[float]]:
+        """동기 배치 인코딩
+
+        Args:
+            texts: 임베딩할 텍스트 리스트
+
+        Returns:
+            벡터 리스트
+        """
+        model = self._load_model()
+        embeddings = model.encode(texts, normalize_embeddings=True)
+        return embeddings.tolist()
+
+    async def embed(self, text: str) -> list[float]:
+        """단일 텍스트 비동기 임베딩
+
+        Args:
+            text: 임베딩할 텍스트
+
+        Returns:
+            정규화된 벡터
+        """
+        loop = asyncio.get_running_loop()
+        results = await loop.run_in_executor(
+            None, partial(self._encode_sync, [text])
+        )
+        return results[0]
+
+    async def embed_batch(self, texts: list[str]) -> list[list[float]]:
+        """배치 텍스트 비동기 임베딩
+
+        Args:
+            texts: 임베딩할 텍스트 리스트
+
+        Returns:
+            정규화된 벡터 리스트
+        """
+        if not texts:
+            return []
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(
+            None, partial(self._encode_sync, texts)
+        )

--- a/src/rag/pgvector_store.py
+++ b/src/rag/pgvector_store.py
@@ -1,0 +1,173 @@
+"""pgvector 기반 VectorStore 구현체
+
+기존 PostgreSQL + SQLAlchemy async 인프라를 재사용하여
+CaseEmbedding 테이블에 벡터를 저장하고 cosine distance로 검색.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+import structlog
+from sqlalchemy import select, delete, text
+from sqlalchemy.ext.asyncio import AsyncEngine
+
+from database.engine import get_session
+from database.models import CaseEmbedding
+from rag.base import BaseVectorStore
+from rag.embedding import Embedder
+from rag.types import RAGQuery, RAGResult
+
+logger = structlog.get_logger()
+
+
+class PgVectorStore(BaseVectorStore):
+    """pgvector 기반 벡터 저장소
+
+    Attributes:
+        engine: SQLAlchemy 비동기 엔진
+        embedder: 텍스트 → 벡터 변환기
+    """
+
+    def __init__(self, engine: AsyncEngine, embedder: Embedder) -> None:
+        """pgvector 저장소 초기화
+
+        Args:
+            engine: SQLAlchemy 비동기 엔진 (기존 DB 엔진 재사용)
+            embedder: BGE-M3 임베딩 생성기
+        """
+        self.engine = engine
+        self.embedder = embedder
+
+    async def ensure_extension(self) -> None:
+        """pgvector 확장 활성화
+
+        PostgreSQL에 vector 확장이 없으면 생성
+        """
+        async with self.engine.begin() as conn:
+            await conn.execute(text("CREATE EXTENSION IF NOT EXISTS vector"))
+
+    async def search(self, query: RAGQuery) -> list[RAGResult]:
+        """유사 문서 검색
+
+        입력 텍스트를 임베딩한 후 cosine distance 기준으로
+        가장 유사한 문서를 반환
+
+        Args:
+            query: 검색 요청 (쿼리 텍스트, top_k, 필터)
+
+        Returns:
+            유사도 순 정렬된 검색 결과 목록
+        """
+        query_vector = await self.embedder.embed(query.query)
+
+        async with get_session(self.engine) as session:
+            distance_expr = CaseEmbedding.embedding.cosine_distance(query_vector)
+
+            stmt = (
+                select(
+                    CaseEmbedding.id,
+                    CaseEmbedding.content,
+                    CaseEmbedding.phase,
+                    CaseEmbedding.case_id,
+                    distance_expr.label("distance"),
+                )
+                .order_by(distance_expr)
+                .limit(query.top_k)
+            )
+
+            if "phase" in query.filters:
+                stmt = stmt.where(CaseEmbedding.phase == query.filters["phase"])
+            if "case_id" in query.filters:
+                stmt = stmt.where(
+                    CaseEmbedding.case_id == int(query.filters["case_id"])
+                )
+
+            result = await session.execute(stmt)
+            rows = result.all()
+
+        results = []
+        for row in rows:
+            score = 1.0 - float(row.distance)
+            results.append(
+                RAGResult(
+                    content=row.content,
+                    score=score,
+                    metadata={
+                        "id": str(row.id),
+                        "phase": row.phase,
+                        "case_id": str(row.case_id),
+                    },
+                )
+            )
+
+        logger.info(
+            "rag_search_complete",
+            query_length=len(query.query),
+            results=len(results),
+            top_score=results[0].score if results else 0.0,
+        )
+        return results
+
+    async def add_document(
+        self,
+        content: str,
+        metadata: dict[str, str] | None = None,
+    ) -> str:
+        """문서 추가
+
+        텍스트를 임베딩하여 CaseEmbedding 레코드로 저장
+
+        Args:
+            content: 저장할 문서 텍스트
+            metadata: 문서 메타데이터 (case_id, phase 필수)
+
+        Returns:
+            생성된 레코드 ID (문자열)
+        """
+        meta = metadata or {}
+        embedding = await self.embedder.embed(content)
+
+        async with get_session(self.engine) as session:
+            record = CaseEmbedding(
+                case_id=int(meta.get("case_id", 0)),
+                phase=meta.get("phase", "unknown"),
+                content=content,
+                embedding=embedding,
+            )
+            session.add(record)
+            await session.commit()
+            await session.refresh(record)
+
+            logger.info(
+                "rag_document_added",
+                record_id=record.id,
+                phase=record.phase,
+                content_length=len(content),
+            )
+            return str(record.id)
+
+    async def delete_document(self, document_id: str) -> bool:
+        """문서 삭제
+
+        Args:
+            document_id: 삭제할 CaseEmbedding 레코드 ID
+
+        Returns:
+            삭제 성공 여부
+        """
+        async with get_session(self.engine) as session:
+            stmt = delete(CaseEmbedding).where(
+                CaseEmbedding.id == int(document_id)
+            )
+            result = await session.execute(stmt)
+            await session.commit()
+            deleted = result.rowcount > 0
+
+            logger.info(
+                "rag_document_deleted",
+                document_id=document_id,
+                success=deleted,
+            )
+            return deleted

--- a/src/rag/service.py
+++ b/src/rag/service.py
@@ -1,0 +1,162 @@
+"""RAG 서비스 — 포렌식 도메인 RAG 로직 캡슐화
+
+VectorStore 위에 포렌식 분석 특화 검색/저장/포맷팅 기능 제공.
+Manager Agent의 전략/계획 수립 단계에서 사용.
+"""
+
+from __future__ import annotations
+
+import structlog
+
+from rag.base import BaseVectorStore
+from rag.types import RAGQuery, RAGResult
+
+logger = structlog.get_logger()
+
+
+class RAGService:
+    """포렌식 분석 RAG 서비스
+
+    Attributes:
+        store: 벡터 저장소 구현체
+        top_k: 검색 시 반환할 최대 결과 수
+        similarity_threshold: 유사도 필터 임계값
+    """
+
+    def __init__(
+        self,
+        store: BaseVectorStore,
+        top_k: int = 3,
+        similarity_threshold: float = 0.5,
+    ) -> None:
+        """RAG 서비스 초기화
+
+        Args:
+            store: 벡터 저장소 (PgVectorStore 등)
+            top_k: 검색 결과 상위 K개
+            similarity_threshold: 유사도 임계값 (이하 결과 제외)
+        """
+        self.store = store
+        self.top_k = top_k
+        self.similarity_threshold = similarity_threshold
+
+    async def search_similar_cases(
+        self, case_description: str, top_k: int | None = None
+    ) -> list[RAGResult]:
+        """유사 케이스의 분석 전략 검색 (strategy 단계용)
+
+        Args:
+            case_description: 사용자 사건 설명 텍스트
+            top_k: 반환 결과 수 (None이면 기본값 사용)
+
+        Returns:
+            유사도 임계값을 넘는 결과 목록
+        """
+        results = await self.store.search(
+            RAGQuery(
+                query=case_description,
+                top_k=top_k or self.top_k,
+                filters={"phase": "strategy"},
+            )
+        )
+        filtered = [r for r in results if r.score >= self.similarity_threshold]
+        logger.info(
+            "rag_similar_cases",
+            total=len(results),
+            above_threshold=len(filtered),
+        )
+        return filtered
+
+    async def search_similar_plans(
+        self, strategy_text: str, top_k: int | None = None
+    ) -> list[RAGResult]:
+        """유사 케이스의 실행 계획 검색 (planning 단계용)
+
+        Args:
+            strategy_text: 분석 전략 텍스트
+            top_k: 반환 결과 수 (None이면 기본값 사용)
+
+        Returns:
+            유사도 임계값을 넘는 결과 목록
+        """
+        results = await self.store.search(
+            RAGQuery(
+                query=strategy_text,
+                top_k=top_k or self.top_k,
+                filters={"phase": "planning"},
+            )
+        )
+        filtered = [r for r in results if r.score >= self.similarity_threshold]
+        logger.info(
+            "rag_similar_plans",
+            total=len(results),
+            above_threshold=len(filtered),
+        )
+        return filtered
+
+    async def store_case_result(
+        self,
+        case_id: int,
+        strategy: str,
+        plan: str,
+        results_summary: str,
+        case_description: str = "",
+    ) -> None:
+        """분석 완료 후 케이스 결과를 벡터 저장소에 저장
+
+        전략, 계획, 실행 결과 요약을 각각 별도 문서로 저장하여
+        향후 유사 케이스 검색에 활용.
+        전략은 사건 설명과 함께 저장하여 검색 정확도 향상.
+
+        Args:
+            case_id: 케이스 ID
+            strategy: 분석 전략 텍스트
+            plan: 실행 계획 텍스트
+            results_summary: 실행 결과 요약 텍스트
+            case_description: 사용자 사건 설명 원문
+        """
+        case_id_str = str(case_id)
+
+        if strategy:
+            content = strategy
+            if case_description:
+                content = f"[사건 설명]\n{case_description}\n\n[분석 전략]\n{strategy}"
+            await self.store.add_document(
+                content=content,
+                metadata={"case_id": case_id_str, "phase": "strategy"},
+            )
+        if plan:
+            await self.store.add_document(
+                content=plan,
+                metadata={"case_id": case_id_str, "phase": "planning"},
+            )
+        if results_summary:
+            await self.store.add_document(
+                content=results_summary,
+                metadata={"case_id": case_id_str, "phase": "execution"},
+            )
+
+        logger.info("rag_case_stored", case_id=case_id)
+
+    @staticmethod
+    def format_rag_context(results: list[RAGResult]) -> str:
+        """RAG 검색 결과를 프롬프트 삽입용 텍스트로 포맷팅
+
+        Args:
+            results: RAG 검색 결과 리스트
+
+        Returns:
+            프롬프트에 삽입할 포맷팅된 텍스트 (결과 없으면 빈 문자열)
+        """
+        if not results:
+            return ""
+
+        lines = []
+        for i, r in enumerate(results, 1):
+            case_id = r.metadata.get("case_id", "?")
+            score = f"{r.score:.2f}"
+            lines.append(f"### 유사 사례 {i} (케이스 #{case_id}, 유사도: {score})")
+            lines.append(r.content)
+            lines.append("")
+
+        return "\n".join(lines)

--- a/src/state/manager.py
+++ b/src/state/manager.py
@@ -67,3 +67,6 @@ class ManagerState(TypedDict):
 
     evidence_repository: Annotated[list[dict[str, Any]], operator.add]
     """Sub-Agent별 증거 산출물 누적 저장소 (artifact + format 구조)"""
+
+    rag_context: str
+    """RAG 검색 결과 텍스트 (전략/계획 수립 시 프롬프트에 주입)"""


### PR DESCRIPTION
## 연관된 이슈
Close #32 

## Summary
pgvector + BGE-M3 기반으로 전략/계획 수립 단계에서 과거 분석 케이스를 RAG로 검색하여 프롬프트에 주입하는 기능 구현

## Description
* **RAG 인프라**
  - `RAGConfig` 설정 추가 (`.env`의 `RAG__ENABLED=true`로 활성화)
  - `Embedder` 클래스: BGE-M3 모델 로드 + `run_in_executor` 기반 async 래핑
  - `CaseEmbedding` ORM 모델: pgvector `Vector(1024)` 컬럼으로 임베딩 저장

* **VectorStore + 서비스**
  - `PgVectorStore(BaseVectorStore)`: 기존 `src/rag/base.py` 인터페이스 구현체
  - `RAGService`: 포렌식 도메인 로직 캡슐화 (유사 전략/계획 검색, 케이스 결과 저장, 컨텍스트 포맷팅)

* **Manager 에이전트 통합**
  - `strategy_node`: 사용자 사건 입력으로 유사 케이스 전략 검색 → 프롬프트 주입
  - `planning_node`: 확정된 전략으로 유사 케이스 실행 계획 검색 → 프롬프트 주입
  - `run_execution` 완료 후: 전략/계획/결과를 벡터 DB에 자동 저장 (학습 루프)
  - 사건 설명 + 전략을 결합 저장하여 검색 정확도 향상

* **엔트리포인트 연결**
  - `scripts/run_agent.py`: RAG 서비스 초기화 + HITL 루프에 전달, `[RAG]` 주입 상태 출력
  - `backend/app/agent_bridge.py`: `get_rag_service()` 싱글톤 추가, 5개 호출 지점에 전달
  - `scripts/rag_manage.py`: RAG 데이터 CRUD 인터랙티브 CLI

* 기타
  - `.env` 설정 중 `RAG__ENABLED=false`(기본값)이면 `rag_service=None`이 전달되어 RAG 미적용
  - 성능 관련 내용은 notion "RAG 구현" 페이지 참고


## Screenshot
* `scripts/run_agent.py` 실행 시
<img width="896" height="380" alt="image" src="https://github.com/user-attachments/assets/eb4e28b6-12bf-4cff-9755-cc7e749d46d3" />

* `scripts/rag_manage.py` 실행 시
<img width="891" height="483" alt="image" src="https://github.com/user-attachments/assets/ae74a762-18da-4a16-849e-9940f1b82a41" />