### PR TITLE
[#36] LLM 토큰 사용량 최적화 및 경량 LLM 분리

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-LLM_API_KEY=sk-your-api-key-here
-LLM_MODEL=gpt-4o
-LLM_BASE_URL=https://api.openai.com/v1
+OPENAI_API_KEY=sk-your-openai-api-key
+ANTHROPIC_API_KEY=sk-ant-your-anthropic-api-key
+MINDLOGIC_API_KEY=your-mindlogic-api-key
 DATABASE_URL=postgresql+asyncpg://user:password@localhost:5432/agent

--- a/scripts/run_agent.py
+++ b/scripts/run_agent.py
@@ -230,20 +230,31 @@ def create_llm_provider(settings, api_choice: str = "default") -> BaseLLMProvide
 
     Args:
         settings: 애플리케이션 설정
-        api_choice: "default" (기존 .env) 또는 "mindlogic" (MindLogic Gateway)
+        api_choice: "default", "anthropic", "anthropic_haiku", "mindlogic" 중 하나
     """
+    from config import LLMConfig
+
+    if api_choice == "anthropic":
+        config = LLMConfig(model=settings.anthropic_model)
+        return AnthropicProvider(config, api_key=settings.anthropic_api_key)
+
+    if api_choice == "anthropic_haiku":
+        config = LLMConfig(model=settings.light_llm.model)
+        return AnthropicProvider(config, api_key=settings.anthropic_api_key)
+
     if api_choice == "mindlogic":
-        from config import LLMConfig
-        mindlogic_config = LLMConfig(
+        config = LLMConfig(
             provider=LLMProvider.OPENAI,
             model=settings.mindlogic_model,
             base_url=settings.mindlogic_base_url,
         )
-        return OpenAIProvider(mindlogic_config, api_key=settings.mindlogic_api_key)
+        return OpenAIProvider(config, api_key=settings.mindlogic_api_key)
 
-    if settings.llm.provider == LLMProvider.OPENAI:
-        return OpenAIProvider(settings.llm, api_key=settings.llm_api_key)
-    return AnthropicProvider(settings.llm, api_key=settings.llm_api_key)
+    config = LLMConfig(
+        provider=LLMProvider.OPENAI,
+        model=settings.openai_model,
+    )
+    return OpenAIProvider(config, api_key=settings.openai_api_key)
 
 
 class ConsoleExecutionCallback:
@@ -397,7 +408,7 @@ async def run_strategy_hitl(state, llm, rag_service=None) -> dict:
         print(f"  {DIM}전략 재수립 중...{RESET}")
 
 
-async def run_planning_hitl(state, llm, mcp, rag_service=None) -> dict:
+async def run_planning_hitl(state, llm, mcp) -> dict:
     """계획 수립 HITL 루프
 
     LLM이 계획을 생성하고 사용자가 승인/수정할 때까지 반복
@@ -408,7 +419,7 @@ async def run_planning_hitl(state, llm, mcp, rag_service=None) -> dict:
     while True:
         start = time.time()
         print(f"  {DIM}LLM 호출 중...{RESET}", end="", flush=True)
-        current = await run_planning(current, llm, mcp, rag_service=rag_service)
+        current = await run_planning(current, llm, mcp)
         print(f"\r  {GREEN}계획 생성 완료{RESET} ({_elapsed(start)})")
 
         rag_ctx = current.get("rag_context", "")
@@ -527,28 +538,52 @@ async def main() -> None:
     config_path = Path(__file__).parent.parent / "config" / "mcp_servers.json"
     settings = load_settings(config_path)
 
-    print(f"\n  {BOLD}API 선택{RESET}:")
-    print(f"    1. 기본 ({settings.llm.provider.value} / {settings.llm.model})")
+    has_default = bool(settings.openai_api_key)
+    has_anthropic = bool(settings.anthropic_api_key)
     has_mindlogic = bool(settings.mindlogic_api_key)
-    if has_mindlogic:
-        print(f"    2. MindLogic Gateway ({settings.mindlogic_model})")
+
+    print(f"\n  {BOLD}API 선택{RESET}:")
+    if has_default:
+        print(f"    1. OpenAI ({settings.openai_model})")
     else:
-        print(f"    {DIM}2. MindLogic Gateway (MINDLOGIC_API_KEY 미설정){RESET}")
+        print(f"    {DIM}1. OpenAI (OPENAI_API_KEY 미설정){RESET}")
+    if has_anthropic:
+        print(f"    2. Anthropic ({settings.anthropic_model})")
+        print(f"       {DIM}└ 경량 LLM: {settings.light_llm.model} (요약/변환용){RESET}")
+        print(f"    3. Anthropic 경량 ({settings.light_llm.model}) — 전 단계")
+    else:
+        print(f"    {DIM}2. Anthropic (ANTHROPIC_API_KEY 미설정){RESET}")
+        print(f"    {DIM}3. Anthropic 경량 (ANTHROPIC_API_KEY 미설정){RESET}")
+    if has_mindlogic:
+        print(f"    4. MindLogic Gateway ({settings.mindlogic_model})")
+        if has_anthropic:
+            print(f"       {DIM}└ 경량 LLM: {settings.light_llm.model} (요약/변환용){RESET}")
+    else:
+        print(f"    {DIM}4. MindLogic Gateway (MINDLOGIC_API_KEY 미설정){RESET}")
 
     api_choice = "default"
-    choice = input(f"  선택 (1/2, 기본=1) > ").strip()
-    if choice == "2" and has_mindlogic:
+    choice = input(f"  선택 (1/2/3/4, 기본=1) > ").strip()
+    if choice == "2" and has_anthropic:
+        api_choice = "anthropic"
+        print(f"  {GREEN}Anthropic API 사용{RESET}: {settings.anthropic_model}")
+    elif choice == "3" and has_anthropic:
+        api_choice = "anthropic_haiku"
+        print(f"  {GREEN}Anthropic 경량 사용{RESET}: {settings.light_llm.model} (전 단계)")
+    elif choice == "4" and has_mindlogic:
         api_choice = "mindlogic"
         print(f"  {GREEN}MindLogic Gateway 사용{RESET}: {settings.mindlogic_model}")
     else:
-        print(f"  {GREEN}기본 API 사용{RESET}: {settings.llm.provider.value} / {settings.llm.model}")
+        print(f"  {GREEN}OpenAI API 사용{RESET}: {settings.openai_model}")
 
     print(f"  {BOLD}MCP{RESET}:  {', '.join(settings.mcp.servers.keys()) or '(없음)'}")
 
-    if api_choice == "default" and not settings.llm_api_key:
-        print(f"  {RED}LLM_API_KEY가 설정되지 않았습니다.{RESET}")
+    if api_choice == "default" and not has_default:
+        print(f"  {RED}OPENAI_API_KEY가 설정되지 않았습니다.{RESET}")
         return
-    if api_choice == "mindlogic" and not settings.mindlogic_api_key:
+    if api_choice in ("anthropic", "anthropic_haiku") and not has_anthropic:
+        print(f"  {RED}ANTHROPIC_API_KEY가 설정되지 않았습니다.{RESET}")
+        return
+    if api_choice == "mindlogic" and not has_mindlogic:
         print(f"  {RED}MINDLOGIC_API_KEY가 설정되지 않았습니다.{RESET}")
         return
     if not settings.database_url:
@@ -573,6 +608,13 @@ async def main() -> None:
         print(f"\r  {GREEN}RAG 초기화 완료{RESET} (모델: {settings.rag.embedding_model})")
 
     llm = create_llm_provider(settings, api_choice)
+
+    light_llm: BaseLLMProvider | None = None
+    if api_choice == "anthropic_haiku":
+        pass
+    elif has_anthropic:
+        light_llm = AnthropicProvider(settings.light_llm, api_key=settings.anthropic_api_key)
+        print(f"  {BOLD}경량 LLM{RESET}: {settings.light_llm.model} (요약/변환용)")
 
     async with MCPClientManager(settings.mcp) as mcp:
         tools = await mcp.list_tools()
@@ -644,7 +686,7 @@ async def main() -> None:
                         print(f"  → 파싱된 실행 단계: {len(state.get('plan_steps', []))}개")
                         cache_key = ""
                     else:
-                        state = await run_planning_hitl(state, llm, mcp, rag_service=rag_service)
+                        state = await run_planning_hitl(state, llm, mcp)
                         if cache_key:
                             _save_cache(cache_key, "planning", {
                                 "analysis_plan": state.get("analysis_plan", ""),
@@ -660,7 +702,7 @@ async def main() -> None:
 
                     exec_start = time.time()
                     cb = ConsoleExecutionCallback()
-                    state = await run_execution(state, llm, mcp, callback=cb, rag_service=rag_service)
+                    state = await run_execution(state, llm, mcp, callback=cb, rag_service=rag_service, light_llm=light_llm)
 
                     task_results = state.get("task_results", [])
                     accumulated_results.extend(task_results)
@@ -671,7 +713,7 @@ async def main() -> None:
                     print_phase(4, "결과 요약")
                     start = time.time()
                     print(f"  {DIM}LLM 호출 중...{RESET}", end="", flush=True)
-                    report_result = await run_report(state, llm)
+                    report_result = await run_report(state, llm, light_llm=light_llm)
                     print(f"\r  {GREEN}요약 완료{RESET} ({_elapsed(start)})")
 
                     summary = report_result.get("summary", "")
@@ -688,7 +730,7 @@ async def main() -> None:
                         start = time.time()
                         print(f"  {DIM}LLM 호출 중...{RESET}", end="", flush=True)
                         state = {**state, "task_results": accumulated_results}
-                        report_result = await run_report(state, llm)
+                        report_result = await run_report(state, llm, light_llm=light_llm)
                         print(f"\r  {GREEN}보고서 생성 완료{RESET} ({_elapsed(start)})")
 
                         report = report_result.get("report", "")

--- a/src/agents/base.py
+++ b/src/agents/base.py
@@ -31,7 +31,8 @@ async def sub_agent_llm_node(
     """Sub-Agent LLM 호출 노드
 
     할당된 task의 목적과 컨텍스트를 바탕으로 LLM이
-    텍스트 응답 또는 도구 호출을 생성
+    텍스트 응답 또는 도구 호출을 생성.
+    도구 스키마는 첫 호출 시 캐싱하여 이후 iteration에서 재사용.
 
     Args:
         state: Sub-Agent 상태
@@ -39,7 +40,12 @@ async def sub_agent_llm_node(
         mcp: 이 Sub-Agent 전용 MCP 클라이언트
         system_prompt: 에이전트별 시스템 프롬프트
     """
-    tools = await mcp.list_tools()
+    cached_tools = state.get("tools")
+    if cached_tools:
+        tools = cached_tools
+    else:
+        tools = await mcp.list_tools()
+
     if isinstance(llm, AnthropicProvider):
         tool_params = mcp_tools_to_anthropic(tools)
     else:
@@ -85,16 +91,14 @@ async def sub_agent_llm_node(
                 for tc in response.tool_calls
             ]
 
-    if response.tool_calls:
-        return {
-            "messages": [assistant_message],
-            "pending_tool_calls": [asdict(tc) for tc in response.tool_calls],
-        }
-
-    return {
+    state_update: dict[str, Any] = {
         "messages": [assistant_message],
-        "pending_tool_calls": [],
+        "pending_tool_calls": [asdict(tc) for tc in response.tool_calls] if response.tool_calls else [],
     }
+    if not cached_tools:
+        state_update["tools"] = tools
+
+    return state_update
 
 
 async def sub_agent_tool_node(

--- a/src/agents/dissect/graph.py
+++ b/src/agents/dissect/graph.py
@@ -20,7 +20,7 @@ from agents.base import (
     sub_agent_llm_node,
 )
 from agents.dissect.nodes import dissect_tool_node
-from prompts.dissect import build_dfxml_fragment_prompt, build_dissect_prompt, format_tool_docs
+from prompts.dissect import build_dissect_prompt, format_tool_docs
 from llm_provider.base import BaseLLMProvider
 from mcp_client.client import MCPClientManager
 from state.sub_agent import SubAgentState
@@ -66,17 +66,11 @@ def _parse_followup(output: str) -> tuple[str, dict[str, Any] | None]:
 
 async def dissect_finalize_node(
     state: SubAgentState,
-    *,
-    llm: BaseLLMProvider,
 ) -> dict[str, Any]:
     """Dissect Sub-Agent finalize 노드
 
-    base finalize로 TaskResult를 생성한 후,
-    follow-up 마커를 파싱하고 DFXML 프래그먼트를 생성
-
-    Args:
-        state: Sub-Agent 상태
-        llm: LLM 프로바이더 (DFXML 생성용)
+    base finalize로 TaskResult를 생성한 후 follow-up 마커를 파싱.
+    DFXML 생성은 Report 단계에서 일괄 처리하므로 여기서는 수행하지 않음.
     """
     base_updates = await sub_agent_finalize_node(state)
 
@@ -85,7 +79,6 @@ async def dissect_finalize_node(
         return {**base_updates, "dfxml_fragment": ""}
 
     task = state["task"]
-    purpose = task.get("step", {}).get("purpose", "")
     output = result.get("output", "")
 
     clean_output, follow_up = _parse_followup(output)
@@ -96,24 +89,7 @@ async def dissect_finalize_node(
     result["output"] = clean_output
     result["follow_up"] = follow_up
 
-    dfxml_fragment = ""
-    if clean_output.strip():
-        try:
-            response = await llm.chat(
-                messages=[{"role": "user", "content": "분석 결과를 DFXML 프래그먼트로 변환해주세요."}],
-                tools=None,
-                system=build_dfxml_fragment_prompt(
-                    agent_name=task.get("agent_name", "dissect"),
-                    task_purpose=purpose,
-                    analysis_output=clean_output,
-                ),
-            )
-            dfxml_fragment = response.content if isinstance(response.content, str) else ""
-            logger.info("dfxml_fragment_generated", task_id=task.get("task_id"), length=len(dfxml_fragment))
-        except Exception as exc:
-            logger.warning("dfxml_fragment_failed", error=str(exc))
-
-    return {**base_updates, "dfxml_fragment": dfxml_fragment}
+    return {**base_updates, "dfxml_fragment": ""}
 
 
 def _should_continue(state: SubAgentState) -> str:
@@ -131,6 +107,7 @@ def build_dissect_graph(
     mcp: MCPClientManager,
     purpose: str = "",
     available_plugins: str = "",
+    light_llm: BaseLLMProvider | None = None,
 ) -> Any:
     """Dissect Sub-Agent subgraph 빌드
 
@@ -146,6 +123,7 @@ def build_dissect_graph(
         mcp: Dissect MCP 서버 전용 클라이언트 매니저
         purpose: 현재 작업 목적 (프롬프트에 주입)
         available_plugins: 사전 조회된 아티팩트 플러그인 목록
+        light_llm: 요약 전용 경량 LLM (None이면 llm 사용)
 
     Returns:
         컴파일된 LangGraph subgraph
@@ -172,11 +150,11 @@ def build_dissect_graph(
     )
     graph.add_node(
         "tools",
-        partial(dissect_tool_node, llm=llm, mcp=mcp),
+        partial(dissect_tool_node, llm=llm, mcp=mcp, summary_llm=light_llm),
     )
     graph.add_node(
         "finalize",
-        partial(dissect_finalize_node, llm=llm),
+        dissect_finalize_node,
     )
 
     graph.add_edge(START, "llm")

--- a/src/agents/dissect/nodes.py
+++ b/src/agents/dissect/nodes.py
@@ -56,6 +56,7 @@ async def dissect_tool_node(
     *,
     llm: BaseLLMProvider,
     mcp: MCPClientManager,
+    summary_llm: BaseLLMProvider | None = None,
 ) -> dict[str, Any]:
     """Dissect 전용 도구 실행 노드
 
@@ -65,8 +66,9 @@ async def dissect_tool_node(
 
     Args:
         state: Sub-Agent 상태
-        llm: LLM 프로바이더 (결과 포맷팅 및 요약용)
+        llm: LLM 프로바이더 (결과 포맷팅용)
         mcp: Dissect MCP 클라이언트
+        summary_llm: 요약 전용 경량 LLM (None이면 llm 사용)
     """
     from llm_provider.anthropic import AnthropicProvider
 
@@ -90,7 +92,7 @@ async def dissect_tool_node(
                 output=raw_content,
                 tool_name=tc["name"],
                 purpose=purpose,
-                llm=llm,
+                llm=summary_llm or llm,
             )
             if tc["name"] not in METADATA_TOOLS:
                 summarized_chunks.append(content)

--- a/src/agents/factory.py
+++ b/src/agents/factory.py
@@ -181,8 +181,14 @@ class AgentRegistry:
         return create_sub_agent_state(task)
 
 
-def create_default_registry() -> AgentRegistry:
-    """Dissect 전용 설정이 등록된 기본 레지스트리 생성"""
+def create_default_registry(
+    light_llm: BaseLLMProvider | None = None,
+) -> AgentRegistry:
+    """Dissect 전용 설정이 등록된 기본 레지스트리 생성
+
+    Args:
+        light_llm: 요약 등 단순 작업에 사용할 경량 LLM (None이면 메인 LLM 사용)
+    """
     from agents.dissect.graph import build_dissect_graph, create_dissect_state
 
     registry = AgentRegistry()
@@ -195,7 +201,8 @@ def create_default_registry() -> AgentRegistry:
     ) -> Any:
         """Dissect 그래프 빌더를 GraphBuilder 시그니처에 맞게 변환"""
         return build_dissect_graph(
-            llm, mcp, purpose=purpose, available_plugins=extra_context
+            llm, mcp, purpose=purpose, available_plugins=extra_context,
+            light_llm=light_llm,
         )
 
     registry.register(

--- a/src/agents/manager/graph.py
+++ b/src/agents/manager/graph.py
@@ -71,20 +71,21 @@ async def run_planning(
     state: ManagerState,
     llm: BaseLLMProvider,
     mcp: MCPClientManager,
-    rag_service: RAGService | None = None,
 ) -> ManagerState:
     """계획 수립 단계 실행
+
+    strategy_node에서 저장된 rag_context를 재사용하므로
+    별도 rag_service 주입이 불필요
 
     Args:
         state: 전략이 확정된 Manager 상태
         llm: LLM 프로바이더
         mcp: MCP 클라이언트 매니저
-        rag_service: RAG 서비스 (None이면 RAG 비활성)
 
     Returns:
         plan_steps가 채워진 상태
     """
-    updates = await planning_node(state, llm=llm, mcp=mcp, rag_service=rag_service)
+    updates = await planning_node(state, llm=llm, mcp=mcp)
     return {**state, **updates}
 
 
@@ -95,6 +96,7 @@ async def run_execution(
     callback: ExecutionCallback | None = None,
     registry: AgentRegistry | None = None,
     rag_service: RAGService | None = None,
+    light_llm: BaseLLMProvider | None = None,
 ) -> ManagerState:
     """Sub-Agent 실행 단계
 
@@ -109,6 +111,7 @@ async def run_execution(
         callback: 진행 상황 콜백 (None이면 무시)
         registry: Sub-Agent 레지스트리 (None이면 기본 레지스트리 사용)
         rag_service: RAG 서비스 (None이면 결과 저장 건너뜀)
+        light_llm: 요약 등 단순 작업에 사용할 경량 LLM (None이면 메인 LLM 사용)
 
     Returns:
         task_results가 채워진 상태
@@ -118,7 +121,7 @@ async def run_execution(
     from datetime import datetime, timezone
 
     if registry is None:
-        registry = create_default_registry()
+        registry = create_default_registry(light_llm=light_llm)
 
     plan_steps = list(state.get("plan_steps", []))
     disk_image_path = state.get("disk_image_path") or ""
@@ -290,12 +293,14 @@ async def run_execution(
 async def run_report(
     state: ManagerState,
     llm: BaseLLMProvider,
+    light_llm: BaseLLMProvider | None = None,
 ) -> dict[str, str]:
     """Report Agent 실행
 
     Args:
         state: 실행 결과가 포함된 Manager 상태
-        llm: LLM 프로바이더
+        llm: 메인 LLM 프로바이더
+        light_llm: 경량 LLM 프로바이더 (DFXML 등 단순 작업용)
 
     Returns:
         {"summary": ..., "report": ..., "dfxml": ...}
@@ -305,7 +310,7 @@ async def run_report(
     if state.get("messages"):
         case_description = state["messages"][0].get("content", "")
 
-    report_graph = build_report_graph(llm)
+    report_graph = build_report_graph(llm, light_llm=light_llm)
     report_state = create_report_state(
         task_results=task_results,
         case_description=case_description,

--- a/src/agents/manager/nodes.py
+++ b/src/agents/manager/nodes.py
@@ -75,36 +75,36 @@ async def planning_node(
     *,
     llm: BaseLLMProvider,
     mcp: MCPClientManager,
-    rag_service: RAGService | None = None,
 ) -> dict[str, Any]:
     """수립된 전략을 바탕으로 세부 실행 계획 수립
+
+    strategy_node에서 저장된 rag_context를 재사용하여
+    중복 RAG 검색을 방지
 
     Args:
         state: Manager 상태
         llm: LLM 프로바이더
         mcp: MCP 클라이언트 매니저 (도구 목록 조회용)
-        rag_service: RAG 서비스 (None이면 RAG 비활성)
     """
     server_names = mcp.connected_servers
     server_list = "\n".join(f"- {name}" for name in server_names) if server_names else ""
 
-    rag_context = ""
-    if rag_service:
-        strategy_text = state.get("analysis_strategy", "")
-        if strategy_text:
-            results = await rag_service.search_similar_plans(strategy_text)
-            rag_context = RAGService.format_rag_context(results)
-            if results:
-                logger.info(
-                    "rag_planning_injected",
-                    hits=len(results),
-                    top_score=results[0].score,
-                    context_length=len(rag_context),
-                )
+    rag_context = state.get("rag_context", "")
 
-    messages = list(state["messages"])
-    if messages and messages[-1].get("role") == "assistant":
-        messages.append({"role": "user", "content": "위 전략을 바탕으로 세부 실행 계획을 수립해주세요."})
+    incoming_messages = state.get("messages", [])
+    has_feedback = (
+        len(incoming_messages) == 1
+        and "[수정 요청]" in incoming_messages[0].get("content", "")
+    )
+
+    if has_feedback:
+        messages = list(incoming_messages)
+    else:
+        strategy_text = state.get("analysis_strategy", "")
+        messages = [
+            {"role": "user", "content": strategy_text},
+            {"role": "user", "content": "위 전략을 바탕으로 세부 실행 계획을 수립해주세요."},
+        ]
 
     response = await llm.chat(
         messages=messages,
@@ -117,13 +117,12 @@ async def planning_node(
     )
     plan_text = response.content if isinstance(response.content, str) else ""
     plan_steps = _parse_plan_steps(plan_text)
-    logger.info("plan_created", length=len(plan_text), steps=len(plan_steps), rag_hits=bool(rag_context))
+    logger.info("plan_created", length=len(plan_text), steps=len(plan_steps))
 
     return {
         "messages": [{"role": "assistant", "content": response.content}],
         "analysis_plan": plan_text,
         "plan_steps": plan_steps,
-        "rag_context": rag_context,
         "phase": "execution",
     }
 
@@ -142,8 +141,8 @@ def routing_node(state: ManagerState) -> dict[str, Any]:
     context = ""
     if task_results:
         context = "\n".join(
-            f"[{r['agent_name']}] {r['output'][:500]}"
-            for r in task_results[-3:]
+            f"[{r['agent_name']}] {r['output'][:300]}"
+            for r in task_results[-2:]
         )
 
     task_queue: list[TaskAssignment] = []

--- a/src/agents/report/graph.py
+++ b/src/agents/report/graph.py
@@ -37,14 +37,18 @@ class ReportAgentState(TypedDict):
     """생성된 DFXML XML 문자열"""
 
 
-def build_report_graph(llm: BaseLLMProvider) -> Any:
+def build_report_graph(
+    llm: BaseLLMProvider,
+    light_llm: BaseLLMProvider | None = None,
+) -> Any:
     """Report Agent subgraph 빌드
 
     그래프 토폴로지:
         START → summary → report → dfxml → END
 
     Args:
-        llm: LLM 프로바이더
+        llm: 메인 LLM 프로바이더 (summary, report 생성)
+        light_llm: 경량 LLM 프로바이더 (dfxml 변환, None이면 llm 사용)
 
     Returns:
         컴파일된 LangGraph subgraph
@@ -53,7 +57,7 @@ def build_report_graph(llm: BaseLLMProvider) -> Any:
 
     graph.add_node("summary", partial(summary_node, llm=llm))
     graph.add_node("report", partial(report_node, llm=llm))
-    graph.add_node("dfxml", partial(dfxml_node, llm=llm))
+    graph.add_node("dfxml", partial(dfxml_node, llm=light_llm or llm))
 
     graph.add_edge(START, "summary")
     graph.add_edge("summary", "report")

--- a/src/agents/report/nodes.py
+++ b/src/agents/report/nodes.py
@@ -7,7 +7,6 @@ from typing import Any
 import structlog
 
 from prompts.report import (
-    build_dfxml_merge_prompt,
     build_dfxml_prompt,
     build_report_prompt,
     build_summary_prompt,
@@ -56,13 +55,21 @@ async def report_node(
 ) -> dict[str, Any]:
     """포렌식 분석 보고서 생성
 
+    summary_node가 생성한 요약이 있으면 이를 활용하여
+    task_results 전문 재전달로 인한 토큰 낭비를 방지
+
     Args:
-        state: Report Agent 상태 (task_results, case_description, strategy 포함)
+        state: Report Agent 상태 (task_results, case_description, strategy, summary 포함)
         llm: LLM 프로바이더
     """
-    task_results = state.get("task_results", [])
     case_description = state.get("case_description", "")
     strategy = state.get("strategy", "")
+    summary = state.get("summary", "")
+
+    if summary:
+        task_results = [{"task_id": "summary", "agent_name": "summary", "status": "success", "output": summary}]
+    else:
+        task_results = state.get("task_results", [])
 
     response = await llm.chat(
         messages=[{"role": "user", "content": "분석 보고서를 작성해주세요."}],
@@ -82,35 +89,28 @@ async def dfxml_node(
 ) -> dict[str, Any]:
     """분석 결과를 DFXML 스키마로 변환
 
-    Evidence Repository에 프래그먼트가 있으면 병합,
-    없으면 task_results에서 전체 생성 (폴백)
+    summary_node의 요약 결과를 기반으로 DFXML을 일괄 생성.
+    per-agent DFXML 프래그먼트 생성이 제거되었으므로
+    항상 요약 또는 task_results에서 직접 변환.
 
     Args:
-        state: Report Agent 상태 (task_results, evidence_repository 포함)
+        state: Report Agent 상태 (task_results, summary 포함)
         llm: LLM 프로바이더
     """
-    evidence_repo = state.get("evidence_repository", [])
-    fragments = [
-        e.get("artifact") or e.get("dfxml_fragment", "")
-        for e in evidence_repo
-        if e.get("artifact") or e.get("dfxml_fragment")
-    ]
+    summary = state.get("summary", "")
 
-    if fragments:
-        response = await llm.chat(
-            messages=[{"role": "user", "content": "DFXML 프래그먼트를 병합해주세요."}],
-            tools=None,
-            system=build_dfxml_merge_prompt(fragments),
-        )
+    if summary:
+        task_results = [{"task_id": "summary", "agent_name": "summary", "status": "success", "output": summary}]
     else:
         task_results = state.get("task_results", [])
-        response = await llm.chat(
-            messages=[{"role": "user", "content": "분석 결과를 DFXML로 변환해주세요."}],
-            tools=None,
-            system=build_dfxml_prompt(task_results),
-        )
+
+    response = await llm.chat(
+        messages=[{"role": "user", "content": "분석 결과를 DFXML로 변환해주세요."}],
+        tools=None,
+        system=build_dfxml_prompt(task_results),
+    )
 
     dfxml = response.content if isinstance(response.content, str) else ""
-    logger.info("dfxml_generated", length=len(dfxml), from_fragments=bool(fragments))
+    logger.info("dfxml_generated", length=len(dfxml))
 
     return {"dfxml": dfxml}

--- a/src/config.py
+++ b/src/config.py
@@ -86,15 +86,16 @@ class RAGConfig(BaseModel):
 
     enabled: bool = False
     embedding_model: str = "BAAI/bge-m3"
-    search_top_k: int = 3
-    similarity_threshold: float = 0.5
+    search_top_k: int = 1
+    similarity_threshold: float = 0.7
 
 
 class Settings(BaseSettings):
     """애플리케이션 전체 설정
 
     환경변수 매핑:
-        LLM_API_KEY            → llm_api_key (기본 OpenAI)
+        OPENAI_API_KEY         → openai_api_key
+        ANTHROPIC_API_KEY      → anthropic_api_key (Anthropic 전용)
         LLM_MODEL              → llm.model (load_settings에서 처리)
         LLM_BASE_URL           → llm.base_url (load_settings에서 처리)
         MINDLOGIC_API_KEY      → mindlogic_api_key (MindLogic Gateway)
@@ -111,10 +112,23 @@ class Settings(BaseSettings):
     )
 
     llm: LLMConfig = Field(default_factory=LLMConfig)
+    light_llm: LLMConfig = Field(
+        default_factory=lambda: LLMConfig(
+            provider=LLMProvider.ANTHROPIC,
+            model="claude-haiku-4-5-20251001",
+            max_tokens=4096,
+        ),
+        description="요약, DFXML 변환 등 단순 작업에 사용하는 경량 LLM",
+    )
     mcp: MCPConfig = Field(default_factory=MCPConfig)
     rag: RAGConfig = Field(default_factory=RAGConfig)
 
-    llm_api_key: str = ""
+    openai_api_key: str = ""
+    openai_model: str = "gpt-4o"
+
+    anthropic_api_key: str = ""
+    anthropic_model: str = "claude-sonnet-4-20250514"
+
     llm_model: str = ""
     llm_base_url: str = ""
 

--- a/src/constants.py
+++ b/src/constants.py
@@ -12,13 +12,13 @@ DEFAULT_MAX_ROWS: int = 200
 MAX_ROWS_PER_PLUGIN: int = 50
 """다중 플러그인 동시 실행 시 플러그인당 최대 행 수"""
 
-SUMMARIZE_THRESHOLD: int = 5000
+SUMMARIZE_THRESHOLD: int = 15000
 """출력 요약을 적용하는 문자 수 임계치"""
 
-CHUNK_SIZE: int = 8000
+CHUNK_SIZE: int = 15000
 """Map-Reduce 청크당 최대 문자 수"""
 
-CHUNK_THRESHOLD: int = 20000
+CHUNK_THRESHOLD: int = 50000
 """Map-Reduce를 적용하는 출력 길이 임계치"""
 
 CALL_TOOL_TIMEOUT: int = 300


### PR DESCRIPTION
## 연관된 이슈 
Close #36

## Summary
에이전트 실행 시 발생하는 불필요한 LLM 호출과 중복 컨텍스트 주입을 제거하고, 요약/변환 등 단순 작업에 경량 LLM(Haiku)을 분리 적용하여 토큰 사용량과 API 비용을 절감 

## Description
### 1. 반복 호출 제거 
- **MCP 도구 스키마 캐싱**: Sub-Agent ReAct 루프에서 매 iteration마다 `mcp.list_tools()`를 호출하던 것을 첫 호출 시 `SubAgentState.tools`에 캐싱하여 이후 재사용 (`src/agents/base.py`)
- **per-step DFXML 생성 제거**: Dissect Sub-Agent가 매 step 종료 시 LLM을 호출해 DFXML 프래그먼트를 생성하던 로직 삭제 → Report 단계에서 일괄 생성으로 통합 (`src/agents/dissect/graph.py`) 
- **Report 내 task_results 재전달 방지**: summary_node가 생성한 요약을 report_node/dfxml_node에서 재사용하여 원본 task_results 전문을 중복 전달하지 않음 (`src/agents/report/nodes.py`)

### 2. 프롬프트 경량화
- **planning_node RAG 중복 검색 제거**: strategy_node에서 저장한 `rag_context`를 재사용하여 planning 단계에서 별도 RAG 검색을 수행하지 않음 (`src/agents/manager/nodes.py`) 
- **planning_node 메시지 구성 최적화**: 누적된 대화 히스토리 대신 확정된 전략 텍스트만 전달하여 입력 토큰 절감 (피드백 수정 요청 시에만 기존 메시지 유지)
- **routing_node 컨텍스트 축소**: 이전 결과 참조를 최근 3개/500자 → 2개/300자로 축소

### 3. 요약 파이프라인 효율화 
- **임계치 상향 조정** (`src/constants.py`): 
    - `SUMMARIZE_THRESHOLD`: 5,000 → 15,000자 
    - `CHUNK_SIZE`: 8,000 → 15,000자
    - `CHUNK_THRESHOLD`: 20,000 → 50,000자
- **RAG 검색 파라미터 조정** (`src/config.py`): 
    - `search_top_k`: 3 → 1, `similarity_threshold`: 0.5 → 0.7

### 4. 경량 LLM 분리 및 프로바이더별 API 키 
- **`light_llm` 설정 추가**: `claude-haiku-4-5-20251001` (4096 max_tokens)을 요약, DFXML 변환 등 단순 작업 전용으로 분리 적용 (`src/config.py`) 
- **프로바이더별 API 키 분리**: 기존 `LLM_API_KEY` 단일 키 → `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` 개별 관리 (`src/config.py`, `.env.example`) 
- **CLI API 선택지 확장**: 기존 2개 → 4개 (OpenAI / Anthropic / Anthropic 경량 / MindLogic) 

## Screenshot
<img width="1041" height="533" alt="image" src="https://github.com/user-attachments/assets/285b1985-79f6-4ed0-82ee-5a95057ca560" />
