### PR TITLE
[#38] 분석 진행 이벤트 영속화 및 재접속 동기화 

### DIFF
--- a/scripts/run_agent.py
+++ b/scripts/run_agent.py
@@ -26,13 +26,11 @@ import time
 from datetime import datetime
 from pathlib import Path
 
+import structlog
 from docx import Document
 from docx.shared import Pt
 
-import structlog
-
 from agents.manager.graph import (
-    ExecutionCallback,
     create_manager_state,
     run_execution,
     run_planning,
@@ -41,7 +39,10 @@ from agents.manager.graph import (
 )
 from config import LLMProvider, load_settings
 from database.engine import get_engine, init_db
+from database.repository import create_case
 from disk_image_validator import validate_image_path
+from event_callback import PersistentExecutionCallback
+from event_store import AnalysisEventStore
 from llm_provider.anthropic import AnthropicProvider
 from llm_provider.base import BaseLLMProvider
 from llm_provider.openai import OpenAIProvider
@@ -49,7 +50,6 @@ from mcp_client.client import MCPClientManager
 from rag.embedding import Embedder
 from rag.pgvector_store import PgVectorStore
 from rag.service import RAGService
-
 
 DIM = "\033[2m"
 BOLD = "\033[1m"
@@ -258,10 +258,26 @@ def create_llm_provider(settings, api_choice: str = "default") -> BaseLLMProvide
 
 
 class ConsoleExecutionCallback:
-    """Sub-Agent 실행 진행 상황을 콘솔에 시각적으로 출력"""
+    """Sub-Agent 실행 진행 상황을 콘솔에 시각적으로 출력
 
-    def __init__(self) -> None:
+    persistent_cb가 설정되면 DB 영속화도 동시 수행
+
+    Attributes:
+        _step_starts: 단계별 시작 시각
+        _persistent_cb: DB 저장용 콜백 (None이면 콘솔만)
+    """
+
+    def __init__(
+        self,
+        persistent_cb: PersistentExecutionCallback | None = None,
+    ) -> None:
+        """ConsoleExecutionCallback 초기화
+
+        Args:
+            persistent_cb: DB 영속화 콜백 (None이면 콘솔 출력만)
+        """
         self._step_starts: dict[int, float] = {}
+        self._persistent_cb = persistent_cb
 
     def on_step_start(self, step_index: int, total: int, step: dict, agent_name: str) -> None:
         """단계 시작 시 진행 바와 단계 정보 출력"""
@@ -272,6 +288,9 @@ class ConsoleExecutionCallback:
         print(f"\n  {bar}")
         print_step_progress(step_index, total, name, agent_name, "running")
 
+        if self._persistent_cb:
+            self._persistent_cb.on_step_start(step_index, total, step, agent_name)
+
     def on_step_done(self, step_index: int, total: int, step: dict, agent_name: str, result: dict) -> None:
         """단계 완료 시 결과 요약 출력"""
         elapsed = _elapsed(self._step_starts.get(step_index, time.time()))
@@ -281,10 +300,16 @@ class ConsoleExecutionCallback:
 
         print_step_result(step_index, total, name, agent_name, status, output, elapsed)
 
+        if self._persistent_cb:
+            self._persistent_cb.on_step_done(step_index, total, step, agent_name, result)
+
     def on_step_skip(self, step_index: int, total: int, step: dict) -> None:
         """수동 단계 건너뛸 때 출력"""
         name = step.get("name", step.get("purpose", ""))
         print_step_progress(step_index, total, name, "manual", "skip")
+
+        if self._persistent_cb:
+            self._persistent_cb.on_step_skip(step_index, total, step)
 
     def _progress_bar(self, current: int, total: int) -> str:
         """텍스트 진행 바 생성"""
@@ -562,7 +587,7 @@ async def main() -> None:
         print(f"    {DIM}4. MindLogic Gateway (MINDLOGIC_API_KEY 미설정){RESET}")
 
     api_choice = "default"
-    choice = input(f"  선택 (1/2/3/4, 기본=1) > ").strip()
+    choice = input("  선택 (1/2/3/4, 기본=1) > ").strip()
     if choice == "2" and has_anthropic:
         api_choice = "anthropic"
         print(f"  {GREEN}Anthropic API 사용{RESET}: {settings.anthropic_model}")
@@ -592,6 +617,7 @@ async def main() -> None:
 
     db_engine = get_engine(settings.database_url)
     await init_db(db_engine)
+    event_store = AnalysisEventStore(db_engine)
     print(f"  {BOLD}DB{RESET}:   초기화 완료")
 
     rag_service = None
@@ -651,6 +677,19 @@ async def main() -> None:
                 break
 
             try:
+                from database.engine import get_session
+
+                async with get_session(db_engine) as session:
+                    case = await create_case(
+                        session,
+                        user_prompt=user_input,
+                        disk_image_path=image_path,
+                        disk_image_format=image_format,
+                    )
+                print(f"  {DIM}케이스 #{case.id} 생성{RESET}")
+
+                persistent_cb = PersistentExecutionCallback(event_store, case.id)
+
                 state = create_manager_state(
                     user_message=user_input,
                     disk_image_path=image_path,
@@ -675,6 +714,11 @@ async def main() -> None:
                         })
                         print(f"[Cache] 전략 캐시 저장 ({cache_key})")
 
+                await persistent_cb.emit_phase_event(
+                    "strategy_ready",
+                    {"strategy": state.get("analysis_strategy", "")[:500]},
+                )
+
                 accumulated_results = []
 
                 while True:
@@ -698,15 +742,23 @@ async def main() -> None:
                             cache_key = ""
 
                     steps = state.get("plan_steps", [])
+                    await persistent_cb.emit_phase_event(
+                        "plan_ready",
+                        {"total_steps": len(steps)},
+                    )
                     print_phase(3, f"Sub-Agent 실행 ({len(steps)}단계)")
 
                     exec_start = time.time()
-                    cb = ConsoleExecutionCallback()
+                    cb = ConsoleExecutionCallback(persistent_cb=persistent_cb)
                     state = await run_execution(state, llm, mcp, callback=cb, rag_service=rag_service, light_llm=light_llm)
 
                     task_results = state.get("task_results", [])
                     accumulated_results.extend(task_results)
 
+                    await persistent_cb.emit_phase_event(
+                        "execution_done",
+                        {"total_steps": len(steps), "elapsed": _elapsed(exec_start)},
+                    )
                     print(f"\n  {GREEN}실행 완료{RESET} ({_elapsed(exec_start)})")
                     print_results_table(task_results)
 
@@ -738,6 +790,10 @@ async def main() -> None:
                         print_section("포렌식 분석 보고서", report)
 
                         docx_path, dfxml_path = save_report(report, dfxml)
+                        await persistent_cb.emit_phase_event(
+                            "report_ready",
+                            {"report_path": str(docx_path)},
+                        )
                         print(f"  {GREEN}보고서 저장{RESET}: {docx_path}")
                         if dfxml_path:
                             print(f"  {GREEN}DFXML 저장{RESET}: {dfxml_path}")

--- a/src/database/models.py
+++ b/src/database/models.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 from datetime import datetime
+from typing import Any
 
 from pgvector.sqlalchemy import Vector
-from sqlalchemy import DateTime, ForeignKey, Integer, String, Text, func
+from sqlalchemy import JSON, DateTime, ForeignKey, Integer, String, Text, func
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
 
 
@@ -34,6 +35,10 @@ class Case(Base):
     disk_image_format: Mapped[str] = mapped_column(String(10), nullable=False)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now()
+    )
+
+    events: Mapped[list["AnalysisEvent"]] = relationship(
+        back_populates="case", cascade="all, delete-orphan"
     )
 
     def __repr__(self) -> str:
@@ -146,3 +151,51 @@ class CaseEmbedding(Base):
     def __repr__(self) -> str:
         """케이스 임베딩 문자열 표현"""
         return f"<CaseEmbedding(id={self.id}, case_id={self.case_id}, phase={self.phase})>"
+
+
+class AnalysisEvent(Base):
+    """분석 진행 이벤트 로그
+
+    WebSocket으로 전송되는 이벤트를 DB에 영속화하여
+    사용자 재접속 시 진행 상황 복원에 사용
+
+    Attributes:
+        id: 이벤트 고유 식별자 (자동 증가)
+        case_id: 소속 케이스 ID
+        event_type: 이벤트 유형 (strategy_ready, step_started, step_completed 등)
+        payload: 이벤트 데이터 (JSON)
+        created_at: 이벤트 발생 시각
+        case: 소속 케이스 관계
+    """
+
+    __tablename__ = "analysis_event"
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    case_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("agent.id"), nullable=False, index=True
+    )
+    event_type: Mapped[str] = mapped_column(String(50), nullable=False, index=True)
+    payload: Mapped[dict[str, Any]] = mapped_column(JSON, nullable=False, default=dict)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+
+    case: Mapped["Case"] = relationship(back_populates="events")
+
+    def __repr__(self) -> str:
+        """이벤트 문자열 표현"""
+        return f"<AnalysisEvent(id={self.id}, type={self.event_type})>"
+
+    def to_dict(self) -> dict[str, Any]:
+        """직렬화 가능한 딕셔너리 변환
+
+        Returns:
+            이벤트 데이터 딕셔너리
+        """
+        return {
+            "id": self.id,
+            "case_id": self.case_id,
+            "event_type": self.event_type,
+            "payload": self.payload,
+            "created_at": self.created_at.isoformat() if self.created_at else None,
+        }

--- a/src/database/repository.py
+++ b/src/database/repository.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from database.models import AgentRun, Case, StepResult
+from database.models import AgentRun, AnalysisEvent, Case, StepResult
 
 
 async def create_case(
@@ -165,4 +167,88 @@ async def get_step_results_by_run(
         .where(StepResult.agent_run_id == agent_run_id)
         .order_by(StepResult.step_index)
     )
+    return list(result.scalars().all())
+
+
+async def save_event(
+    session: AsyncSession,
+    case_id: int,
+    event_type: str,
+    payload: dict[str, Any],
+) -> AnalysisEvent:
+    """분석 이벤트 저장
+
+    Args:
+        session: 비동기 DB 세션
+        case_id: 케이스 ID
+        event_type: 이벤트 유형
+        payload: 이벤트 데이터
+
+    Returns:
+        생성된 AnalysisEvent 인스턴스
+    """
+    event = AnalysisEvent(
+        case_id=case_id,
+        event_type=event_type,
+        payload=payload,
+    )
+    session.add(event)
+    await session.commit()
+    await session.refresh(event)
+    return event
+
+
+async def get_events_after(
+    session: AsyncSession,
+    case_id: int,
+    after_id: int = 0,
+) -> list[AnalysisEvent]:
+    """특정 이벤트 ID 이후의 이벤트 목록 조회
+
+    사용자 재접속 시 미수신 이벤트를 복원하기 위해 사용
+
+    Args:
+        session: 비동기 DB 세션
+        case_id: 케이스 ID
+        after_id: 이 ID 이후의 이벤트만 조회 (0이면 전체)
+
+    Returns:
+        이벤트 목록 (생성 순)
+    """
+    stmt = (
+        select(AnalysisEvent)
+        .where(
+            AnalysisEvent.case_id == case_id,
+            AnalysisEvent.id > after_id,
+        )
+        .order_by(AnalysisEvent.id.asc())
+    )
+    result = await session.execute(stmt)
+    return list(result.scalars().all())
+
+
+async def get_events_by_type(
+    session: AsyncSession,
+    case_id: int,
+    event_type: str,
+) -> list[AnalysisEvent]:
+    """특정 유형의 이벤트 목록 조회
+
+    Args:
+        session: 비동기 DB 세션
+        case_id: 케이스 ID
+        event_type: 조회할 이벤트 유형
+
+    Returns:
+        해당 유형 이벤트 목록 (생성 순)
+    """
+    stmt = (
+        select(AnalysisEvent)
+        .where(
+            AnalysisEvent.case_id == case_id,
+            AnalysisEvent.event_type == event_type,
+        )
+        .order_by(AnalysisEvent.id.asc())
+    )
+    result = await session.execute(stmt)
     return list(result.scalars().all())

--- a/src/event_callback.py
+++ b/src/event_callback.py
@@ -1,0 +1,140 @@
+"""이벤트 저장소 기반 ExecutionCallback 구현"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import Any
+
+from event_store import AnalysisEventStore
+from state.messages import TaskResult
+
+
+class PersistentExecutionCallback:
+    """DB 영속화를 수행하는 ExecutionCallback 구현체
+
+    Sub-Agent 실행 진행 상황을 AnalysisEventStore를 통해
+    DB에 저장하고 리스너에 브로드캐스트
+
+    Attributes:
+        _event_store: 이벤트 저장소
+        _case_id: 케이스 ID
+        _step_start_times: 단계별 시작 시각 기록
+    """
+
+    def __init__(self, event_store: AnalysisEventStore, case_id: int) -> None:
+        """PersistentExecutionCallback 초기화
+
+        Args:
+            event_store: 이벤트 저장소
+            case_id: 케이스 ID
+        """
+        self._event_store = event_store
+        self._case_id = case_id
+        self._step_start_times: dict[int, float] = {}
+
+    def on_step_start(
+        self,
+        step_index: int,
+        total: int,
+        step: dict[str, Any],
+        agent_name: str,
+    ) -> None:
+        """단계 시작 이벤트 발행
+
+        Args:
+            step_index: 단계 인덱스
+            total: 전체 단계 수
+            step: 단계 정보
+            agent_name: Sub-Agent 이름
+        """
+        self._step_start_times[step_index] = time.monotonic()
+        asyncio.create_task(
+            self._event_store.emit(
+                self._case_id,
+                "step_started",
+                {
+                    "step_index": step_index,
+                    "total": total,
+                    "step_name": step.get("name", ""),
+                    "agent_name": agent_name,
+                },
+            )
+        )
+
+    def on_step_done(
+        self,
+        step_index: int,
+        total: int,
+        step: dict[str, Any],
+        agent_name: str,
+        result: TaskResult,
+    ) -> None:
+        """단계 완료 이벤트 발행
+
+        Args:
+            step_index: 단계 인덱스
+            total: 전체 단계 수
+            step: 단계 정보
+            agent_name: Sub-Agent 이름
+            result: 작업 결과
+        """
+        start = self._step_start_times.pop(step_index, None)
+        elapsed = f"{time.monotonic() - start:.1f}s" if start else "N/A"
+
+        asyncio.create_task(
+            self._event_store.emit(
+                self._case_id,
+                "step_completed",
+                {
+                    "step_index": step_index,
+                    "total": total,
+                    "step_name": step.get("name", ""),
+                    "agent_name": agent_name,
+                    "status": result.get("status", ""),
+                    "output_preview": result.get("output", "")[:300],
+                    "elapsed": elapsed,
+                },
+            )
+        )
+
+    def on_step_skip(
+        self,
+        step_index: int,
+        total: int,
+        step: dict[str, Any],
+    ) -> None:
+        """단계 건너뛰기 이벤트 발행
+
+        Args:
+            step_index: 단계 인덱스
+            total: 전체 단계 수
+            step: 단계 정보
+        """
+        asyncio.create_task(
+            self._event_store.emit(
+                self._case_id,
+                "step_completed",
+                {
+                    "step_index": step_index,
+                    "total": total,
+                    "step_name": step.get("name", ""),
+                    "agent_name": "manual",
+                    "status": "skip",
+                    "output_preview": "",
+                    "elapsed": "0s",
+                },
+            )
+        )
+
+    async def emit_phase_event(self, event_type: str, payload: dict[str, Any]) -> None:
+        """범용 단계 이벤트 발행
+
+        strategy_ready, plan_ready, execution_done, report_ready 등
+        ExecutionCallback 프로토콜 외의 이벤트 발행에 사용
+
+        Args:
+            event_type: 이벤트 유형
+            payload: 이벤트 데이터
+        """
+        await self._event_store.emit(self._case_id, event_type, payload)

--- a/src/event_store.py
+++ b/src/event_store.py
@@ -1,0 +1,229 @@
+"""분석 이벤트 영속화 및 브로드캐스트 모듈
+
+WebSocket 전송과 DB 저장을 통합 관리.
+DB 저장 실패가 이벤트 전송을 블로킹하지 않도록 비동기 분리 처리.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager
+from typing import Any, Protocol
+
+import structlog
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
+
+from database.repository import get_events_after, save_event
+
+logger = structlog.get_logger()
+
+
+class EventListener(Protocol):
+    """이벤트 수신 리스너 프로토콜
+
+    WebSocket 연결이나 기타 전송 채널이 구현
+    """
+
+    async def on_event(self, event_type: str, data: dict[str, Any]) -> None:
+        """이벤트 수신 시 호출
+
+        Args:
+            event_type: 이벤트 유형
+            data: 이벤트 페이로드
+        """
+        ...
+
+
+class AnalysisEventStore:
+    """분석 이벤트 영속화 및 브로드캐스트 관리자
+
+    이벤트 발행 시 DB 저장과 리스너 전송을 동시에 수행.
+    case_id별 리스너를 관리하며, 재접속 시 미수신 이벤트 복원 지원.
+
+    Attributes:
+        _engine: SQLAlchemy 비동기 엔진
+        _session_factory: 세션 팩토리
+        _listeners: case_id별 리스너 목록
+        _lock: 리스너 목록 동시성 보호 락
+    """
+
+    def __init__(
+        self,
+        engine: AsyncEngine,
+        session_factory: async_sessionmaker[AsyncSession] | None = None,
+    ) -> None:
+        """AnalysisEventStore 초기화
+
+        Args:
+            engine: SQLAlchemy 비동기 엔진
+            session_factory: 세션 팩토리 (None이면 엔진 기반 자동 생성)
+        """
+        self._engine = engine
+        self._session_factory = session_factory or async_sessionmaker(
+            engine, expire_on_commit=False
+        )
+        self._listeners: dict[int, list[EventListener]] = {}
+        self._lock = asyncio.Lock()
+
+    @asynccontextmanager
+    async def _get_session(self) -> AsyncGenerator[AsyncSession, None]:
+        """내부 세션 컨텍스트 매니저"""
+        async with self._session_factory() as session:
+            yield session
+
+    async def add_listener(self, case_id: int, listener: EventListener) -> None:
+        """case_id에 리스너 등록
+
+        Args:
+            case_id: 케이스 ID
+            listener: 이벤트 리스너
+        """
+        async with self._lock:
+            if case_id not in self._listeners:
+                self._listeners[case_id] = []
+            self._listeners[case_id].append(listener)
+
+    async def remove_listener(self, case_id: int, listener: EventListener) -> None:
+        """case_id에서 리스너 제거
+
+        Args:
+            case_id: 케이스 ID
+            listener: 제거할 리스너
+        """
+        async with self._lock:
+            listeners = self._listeners.get(case_id, [])
+            if listener in listeners:
+                listeners.remove(listener)
+            if not listeners:
+                self._listeners.pop(case_id, None)
+
+    async def emit(
+        self,
+        case_id: int,
+        event_type: str,
+        payload: dict[str, Any],
+    ) -> int | None:
+        """이벤트 발행 (DB 저장 + 리스너 브로드캐스트)
+
+        DB 저장 실패 시에도 리스너 전송은 정상 수행.
+
+        Args:
+            case_id: 케이스 ID
+            event_type: 이벤트 유형
+            payload: 이벤트 데이터
+
+        Returns:
+            저장된 이벤트 ID (DB 저장 실패 시 None)
+        """
+        event_id = await self._persist(case_id, event_type, payload)
+
+        broadcast_data = {
+            "type": event_type,
+            **payload,
+        }
+        if event_id is not None:
+            broadcast_data["event_id"] = event_id
+
+        await self._broadcast(case_id, event_type, broadcast_data)
+        return event_id
+
+    async def replay(
+        self,
+        case_id: int,
+        listener: EventListener,
+        after_id: int = 0,
+    ) -> int:
+        """미수신 이벤트 재전송
+
+        사용자 재접속 시 after_id 이후의 이벤트를 조회하여 리스너에 전송
+
+        Args:
+            case_id: 케이스 ID
+            listener: 재전송 대상 리스너
+            after_id: 이 ID 이후의 이벤트만 재전송 (0이면 전체)
+
+        Returns:
+            재전송된 이벤트 수
+        """
+        try:
+            async with self._get_session() as session:
+                events = await get_events_after(session, case_id, after_id)
+        except Exception:
+            logger.exception("event_replay_query_failed", case_id=case_id)
+            return 0
+
+        for event in events:
+            replay_data = {
+                "type": event.event_type,
+                "event_id": event.id,
+                "replay": True,
+                **event.payload,
+            }
+            try:
+                await listener.on_event(event.event_type, replay_data)
+            except Exception:
+                logger.exception(
+                    "event_replay_send_failed",
+                    case_id=case_id,
+                    event_id=event.id,
+                )
+                break
+
+        return len(events)
+
+    async def _persist(
+        self,
+        case_id: int,
+        event_type: str,
+        payload: dict[str, Any],
+    ) -> int | None:
+        """이벤트 DB 저장 (실패 시 None 반환, 예외 전파 차단)
+
+        Args:
+            case_id: 케이스 ID
+            event_type: 이벤트 유형
+            payload: 이벤트 데이터
+
+        Returns:
+            저장된 이벤트 ID 또는 None
+        """
+        try:
+            async with self._get_session() as session:
+                event = await save_event(session, case_id, event_type, payload)
+                return event.id
+        except Exception:
+            logger.exception(
+                "event_persist_failed",
+                case_id=case_id,
+                event_type=event_type,
+            )
+            return None
+
+    async def _broadcast(
+        self,
+        case_id: int,
+        event_type: str,
+        data: dict[str, Any],
+    ) -> None:
+        """등록된 리스너에 이벤트 브로드캐스트
+
+        개별 리스너 전송 실패는 다른 리스너에 영향을 주지 않음
+
+        Args:
+            case_id: 케이스 ID
+            event_type: 이벤트 유형
+            data: 전송할 데이터
+        """
+        async with self._lock:
+            listeners = list(self._listeners.get(case_id, []))
+
+        for listener in listeners:
+            try:
+                await listener.on_event(event_type, data)
+            except Exception:
+                logger.exception(
+                    "event_broadcast_failed",
+                    case_id=case_id,
+                    event_type=event_type,
+                )


### PR DESCRIPTION
## 연관된 이슈
Close #38 

## Summary
- WebSocket으로 전송되는 분석 진행 이벤트를 `analysis_event` 테이블에 영속화
- CLI(`run_agent.py`) 실행 시 전 단계 이벤트 자동 기록 (strategy_ready → plan_ready → step_started/completed → execution_done → 
report_ready) 
- `AnalysisEventStore.replay(after_id)` 메서드로 재접속 시 미수신 이벤트 복원 지원

## Description
### 변경 내용 
- `src/database/models.py` - `AnalysisEvent` 모델 추가, `Case.events` relationship
- `src/database/repository.py` - `save_event`, `get_events_after`, `get_events_by_type` 함수
- `src/event_store.py` - `AnalysisEventStore` (DB 저장 + 리스너 브로드캐스트, DB 실패 시 전송 보장) 
- `src/event_callback.py` - `PersistentExecutionCallback` (ExecutionCallback → 이벤트 저장소 연동)
- `scripts/run_agent.py` - 케이스 DB 저장, `ConsoleExecutionCallback`에 `PersistentExecutionCallback` 합성

## Screenshot
<img width="1279" height="445" alt="SCR-20260521-czss" src="https://github.com/user-attachments/assets/328fb64f-402c-442a-aacc-e07c2cd1b229" />