### PR TITLE
[#39] 노드 간 관계 데이터 및 그래프 레이아웃 

### DIFF
--- a/src/agents/manager/graph.py
+++ b/src/agents/manager/graph.py
@@ -6,22 +6,30 @@ HITL 게이트는 run_agent.py에서 명시적으로 제어하므로,
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
 from typing import Any, Protocol
 
 import structlog
 
 from agents.factory import AgentRegistry, create_default_registry
-from constants import EXECUTION_STEP_DELAY, MAX_FOLLOWUP_STEPS
 from agents.manager.nodes import (
     _extract_agent_name,
-    _parse_plan_steps,
-    strategy_node,
     planning_node,
+    strategy_node,
 )
 from agents.report.graph import build_report_graph, create_report_state
+from constants import EXECUTION_STEP_DELAY, MAX_FOLLOWUP_STEPS
 from llm_provider.base import BaseLLMProvider
 from mcp_client.client import MCPClientManager
+from node_graph import (
+    add_followup_step,
+    create_initial_graph,
+    update_planning_done,
+    update_report_done,
+    update_report_started,
+    update_step_done,
+    update_step_started,
+    update_strategy_done,
+)
 from rag.service import RAGService
 from state.manager import ManagerState
 from state.messages import TaskAssignment, TaskResult
@@ -64,7 +72,12 @@ async def run_strategy(
     updates = await strategy_node(
         state, llm=llm, system_profile=system_profile, rag_service=rag_service
     )
-    return {**state, **updates}
+    new_state = {**state, **updates}
+    graph = new_state.get("node_graph") or create_initial_graph()
+    new_state["node_graph"] = update_strategy_done(
+        graph, new_state.get("analysis_strategy", "")
+    )
+    return new_state
 
 
 async def run_planning(
@@ -86,7 +99,12 @@ async def run_planning(
         plan_steps가 채워진 상태
     """
     updates = await planning_node(state, llm=llm, mcp=mcp)
-    return {**state, **updates}
+    new_state = {**state, **updates}
+    graph = new_state.get("node_graph") or create_initial_graph()
+    new_state["node_graph"] = update_planning_done(
+        graph, new_state.get("plan_steps", [])
+    )
+    return new_state
 
 
 async def run_execution(
@@ -129,6 +147,7 @@ async def run_execution(
     evidence_repo: list[dict[str, Any]] = []
     followup_count = 0
     total = len(plan_steps)
+    graph = state.get("node_graph") or create_initial_graph()
 
     connected_servers = mcp.connected_servers
     default_server = connected_servers[0] if connected_servers else ""
@@ -170,12 +189,14 @@ async def run_execution(
                 "artifacts": [],
             }
             results.append(result)
+            graph = update_step_done(graph, i, "skip")
             if callback:
                 callback.on_step_skip(i, total, step)
             logger.info("manual_step", step=step.get("index"), purpose=purpose)
             i += 1
             continue
 
+        graph = update_step_started(graph, i)
         if callback:
             callback.on_step_start(i, total, step, agent_name)
 
@@ -234,13 +255,19 @@ async def run_execution(
             }
             results.append(error_result)
 
+        last_result = results[-1]
+        graph = update_step_done(
+            graph, i, last_result.get("status", "error"),
+            output_summary=last_result.get("output", ""),
+        )
+
         if callback:
-            step_result_for_cb = dict(results[-1])
+            step_result_for_cb = dict(last_result)
             if evidence_repo and evidence_repo[-1].get("task_id") == task["task_id"]:
                 step_result_for_cb["artifact"] = evidence_repo[-1]["artifact"]
             callback.on_step_done(i, total, step, agent_name, step_result_for_cb)
 
-        follow_up = results[-1].get("follow_up")
+        follow_up = last_result.get("follow_up")
         if follow_up and followup_count < MAX_FOLLOWUP_STEPS:
             suggested = follow_up.get("suggested_step", {})
             new_step = {
@@ -254,6 +281,9 @@ async def run_execution(
             plan_steps.append(new_step)
             total = len(plan_steps)
             followup_count += 1
+            graph = add_followup_step(
+                graph, len(plan_steps) - 1, new_step["name"]
+            )
             logger.info(
                 "followup_step_added",
                 reason=follow_up.get("reason"),
@@ -286,6 +316,7 @@ async def run_execution(
         **state,
         "task_results": results,
         "evidence_repository": evidence_repo,
+        "node_graph": graph,
         "phase": "report",
     }
 
@@ -310,6 +341,9 @@ async def run_report(
     if state.get("messages"):
         case_description = state["messages"][0].get("content", "")
 
+    graph = state.get("node_graph") or create_initial_graph()
+    graph = update_report_started(graph)
+
     report_graph = build_report_graph(llm, light_llm=light_llm)
     report_state = create_report_state(
         task_results=task_results,
@@ -319,10 +353,13 @@ async def run_report(
     )
 
     result = await report_graph.ainvoke(report_state)
+    graph = update_report_done(graph)
+
     return {
         "summary": result.get("summary", ""),
         "report": result.get("report", ""),
         "dfxml": result.get("dfxml", ""),
+        "node_graph": graph,
     }
 
 
@@ -359,4 +396,5 @@ def create_manager_state(
         hitl_type="",
         evidence_repository=[],
         rag_context="",
+        node_graph=create_initial_graph(),
     )

--- a/src/node_graph.py
+++ b/src/node_graph.py
@@ -1,0 +1,391 @@
+"""노드 그래프 빌드 및 업데이트 모듈
+
+프론트엔드 DAG 시각화를 위한 노드/엣지 구조를 생성하고 갱신.
+각 오케스트레이션 단계(strategy, planning, execution, report) 완료 시
+해당 노드의 상태와 엣지 데이터를 업데이트.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from state.messages import NodeEdge, NodeRelation
+
+
+def _truncate(text: str, max_len: int = 300) -> str:
+    """텍스트를 최대 길이로 자르기
+
+    Args:
+        text: 원본 텍스트
+        max_len: 최대 길이
+
+    Returns:
+        잘린 텍스트
+    """
+    if len(text) <= max_len:
+        return text
+    return text[: max_len - 3] + "..."
+
+
+def create_initial_graph() -> dict[str, Any]:
+    """초기 노드 그래프 생성
+
+    strategy와 planning 노드만 포함된 초기 그래프 반환.
+    execution step 노드는 planning 완료 후 동적 추가.
+
+    Returns:
+        초기 노드 그래프 (nodes, edges)
+    """
+    strategy_node: NodeRelation = {
+        "id": "strategy",
+        "label": "분석 전략",
+        "type": "strategy",
+        "row": 0,
+        "col": 0,
+        "status": "pending",
+        "inputs": [],
+        "outputs": [],
+    }
+    planning_node: NodeRelation = {
+        "id": "planning",
+        "label": "실행 계획",
+        "type": "planning",
+        "row": 1,
+        "col": 0,
+        "status": "pending",
+        "inputs": [],
+        "outputs": [],
+    }
+
+    edge: NodeEdge = {
+        "from_node": "strategy",
+        "to_node": "planning",
+        "data_key": "analysis_strategy",
+        "data_summary": "",
+    }
+
+    strategy_node["outputs"] = [edge]
+    planning_node["inputs"] = [edge]
+
+    return {
+        "nodes": [strategy_node, planning_node],
+        "edges": [edge],
+    }
+
+
+def _find_node(graph: dict[str, Any], node_id: str) -> NodeRelation | None:
+    """그래프에서 노드 ID로 검색
+
+    Args:
+        graph: 노드 그래프
+        node_id: 검색할 노드 ID
+
+    Returns:
+        노드 또는 None
+    """
+    for node in graph.get("nodes", []):
+        if node["id"] == node_id:
+            return node
+    return None
+
+
+def update_strategy_done(
+    graph: dict[str, Any],
+    strategy_text: str,
+) -> dict[str, Any]:
+    """전략 수립 완료 시 그래프 업데이트
+
+    Args:
+        graph: 현재 노드 그래프
+        strategy_text: 확정된 전략 텍스트
+
+    Returns:
+        업데이트된 노드 그래프
+    """
+    strategy = _find_node(graph, "strategy")
+    if strategy:
+        strategy["status"] = "success"
+
+    planning = _find_node(graph, "planning")
+    if planning:
+        planning["status"] = "running"
+
+    for edge in graph.get("edges", []):
+        if (
+            edge["from_node"] == "strategy"
+            and edge["to_node"] == "planning"
+        ):
+            edge["data_summary"] = _truncate(strategy_text)
+
+    return graph
+
+
+def update_planning_done(
+    graph: dict[str, Any],
+    plan_steps: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """계획 수립 완료 시 그래프 업데이트
+
+    plan_steps 기반으로 execution 노드와 report 노드를 동적 생성
+
+    Args:
+        graph: 현재 노드 그래프
+        plan_steps: 파싱된 실행 단계 목록
+
+    Returns:
+        업데이트된 노드 그래프
+    """
+    planning = _find_node(graph, "planning")
+    if planning:
+        planning["status"] = "success"
+
+    nodes: list[NodeRelation] = list(graph.get("nodes", []))
+    edges: list[NodeEdge] = list(graph.get("edges", []))
+
+    execution_start_row = 2
+    prev_node_id = "planning"
+
+    for i, step in enumerate(plan_steps):
+        step_id = f"step_{i}"
+        step_name = step.get(
+            "name", step.get("purpose", f"단계 {i + 1}")
+        )
+
+        edge_from_prev: NodeEdge = {
+            "from_node": prev_node_id,
+            "to_node": step_id,
+            "data_key": (
+                "plan_step" if prev_node_id == "planning"
+                else "task_result"
+            ),
+            "data_summary": "",
+        }
+
+        step_node: NodeRelation = {
+            "id": step_id,
+            "label": step_name,
+            "type": "execution",
+            "row": execution_start_row + i,
+            "col": 0,
+            "status": "pending",
+            "inputs": [edge_from_prev],
+            "outputs": [],
+        }
+
+        prev = _find_node({"nodes": nodes}, prev_node_id)
+        if prev:
+            prev["outputs"].append(edge_from_prev)
+
+        nodes.append(step_node)
+        edges.append(edge_from_prev)
+        prev_node_id = step_id
+
+    report_row = execution_start_row + len(plan_steps)
+    report_node: NodeRelation = {
+        "id": "report",
+        "label": "보고서 생성",
+        "type": "report",
+        "row": report_row,
+        "col": 0,
+        "status": "pending",
+        "inputs": [],
+        "outputs": [],
+    }
+
+    for i in range(len(plan_steps)):
+        step_id = f"step_{i}"
+        edge_to_report: NodeEdge = {
+            "from_node": step_id,
+            "to_node": "report",
+            "data_key": "task_results",
+            "data_summary": "",
+        }
+        step_node = _find_node({"nodes": nodes}, step_id)
+        if step_node:
+            step_node["outputs"].append(edge_to_report)
+        report_node["inputs"].append(edge_to_report)
+        edges.append(edge_to_report)
+
+    nodes.append(report_node)
+
+    return {"nodes": nodes, "edges": edges}
+
+
+def update_step_started(
+    graph: dict[str, Any],
+    step_index: int,
+) -> dict[str, Any]:
+    """실행 단계 시작 시 그래프 업데이트
+
+    Args:
+        graph: 현재 노드 그래프
+        step_index: 시작된 단계 인덱스
+
+    Returns:
+        업데이트된 노드 그래프
+    """
+    step_node = _find_node(graph, f"step_{step_index}")
+    if step_node:
+        step_node["status"] = "running"
+    return graph
+
+
+def update_step_done(
+    graph: dict[str, Any],
+    step_index: int,
+    status: str,
+    output_summary: str = "",
+) -> dict[str, Any]:
+    """실행 단계 완료 시 그래프 업데이트
+
+    Args:
+        graph: 현재 노드 그래프
+        step_index: 완료된 단계 인덱스
+        status: 결과 상태 (success | error | skip)
+        output_summary: 출력 요약 (엣지 data_summary에 사용)
+
+    Returns:
+        업데이트된 노드 그래프
+    """
+    step_id = f"step_{step_index}"
+    step_node = _find_node(graph, step_id)
+    if step_node:
+        step_node["status"] = status
+
+    if output_summary:
+        summary = _truncate(output_summary)
+        for edge in graph.get("edges", []):
+            if edge["from_node"] == step_id:
+                edge["data_summary"] = summary
+
+    return graph
+
+
+def add_followup_step(
+    graph: dict[str, Any],
+    step_index: int,
+    step_name: str,
+) -> dict[str, Any]:
+    """follow-up 단계 동적 추가
+
+    Args:
+        graph: 현재 노드 그래프
+        step_index: 새 단계의 인덱스
+        step_name: 단계 이름
+
+    Returns:
+        업데이트된 노드 그래프
+    """
+    nodes: list[NodeRelation] = graph.get("nodes", [])
+    edges: list[NodeEdge] = graph.get("edges", [])
+
+    report_node = _find_node(graph, "report")
+    report_row = (
+        report_node["row"] if report_node else step_index + 2
+    )
+
+    prev_step_id = (
+        f"step_{step_index - 1}" if step_index > 0 else "planning"
+    )
+    step_id = f"step_{step_index}"
+
+    edge_from_prev: NodeEdge = {
+        "from_node": prev_step_id,
+        "to_node": step_id,
+        "data_key": "task_result",
+        "data_summary": "",
+    }
+    edge_to_report: NodeEdge = {
+        "from_node": step_id,
+        "to_node": "report",
+        "data_key": "task_results",
+        "data_summary": "",
+    }
+
+    new_node: NodeRelation = {
+        "id": step_id,
+        "label": step_name,
+        "type": "execution",
+        "row": report_row,
+        "col": 0,
+        "status": "pending",
+        "inputs": [edge_from_prev],
+        "outputs": [edge_to_report],
+    }
+
+    prev_node = _find_node(graph, prev_step_id)
+    if prev_node:
+        prev_node["outputs"].append(edge_from_prev)
+
+    if report_node:
+        report_node["row"] = report_row + 1
+        report_node["inputs"].append(edge_to_report)
+
+    nodes.append(new_node)
+    edges.extend([edge_from_prev, edge_to_report])
+
+    return {"nodes": nodes, "edges": edges}
+
+
+def update_report_started(graph: dict[str, Any]) -> dict[str, Any]:
+    """보고서 생성 시작 시 그래프 업데이트
+
+    Args:
+        graph: 현재 노드 그래프
+
+    Returns:
+        업데이트된 노드 그래프
+    """
+    report = _find_node(graph, "report")
+    if report:
+        report["status"] = "running"
+    return graph
+
+
+def update_report_done(graph: dict[str, Any]) -> dict[str, Any]:
+    """보고서 생성 완료 시 그래프 업데이트
+
+    Args:
+        graph: 현재 노드 그래프
+
+    Returns:
+        업데이트된 노드 그래프
+    """
+    report = _find_node(graph, "report")
+    if report:
+        report["status"] = "success"
+    return graph
+
+
+def get_graph_response(graph: dict[str, Any]) -> dict[str, Any]:
+    """프론트엔드 API 응답용 그래프 데이터 변환
+
+    nodes와 edges를 분리된 리스트로 반환
+
+    Args:
+        graph: 내부 노드 그래프
+
+    Returns:
+        API 응답 형식 (nodes, edges)
+    """
+    nodes = []
+    for node in graph.get("nodes", []):
+        nodes.append({
+            "id": node["id"],
+            "label": node["label"],
+            "type": node["type"],
+            "row": node["row"],
+            "col": node["col"],
+            "status": node["status"],
+        })
+
+    edges = []
+    for edge in graph.get("edges", []):
+        edges.append({
+            "from_node": edge["from_node"],
+            "to_node": edge["to_node"],
+            "data_key": edge["data_key"],
+            "data_summary": edge["data_summary"],
+        })
+
+    return {"nodes": nodes, "edges": edges}

--- a/src/state/__init__.py
+++ b/src/state/__init__.py
@@ -1,11 +1,19 @@
 """멀티 에이전트 상태 스키마 패키지"""
 
-from state.messages import AgentMessage, TaskAssignment, TaskResult
 from state.manager import ManagerState
+from state.messages import (
+    AgentMessage,
+    NodeEdge,
+    NodeRelation,
+    TaskAssignment,
+    TaskResult,
+)
 from state.sub_agent import SubAgentState
 
 __all__ = [
     "AgentMessage",
+    "NodeEdge",
+    "NodeRelation",
     "TaskAssignment",
     "TaskResult",
     "ManagerState",

--- a/src/state/manager.py
+++ b/src/state/manager.py
@@ -70,3 +70,6 @@ class ManagerState(TypedDict):
 
     rag_context: str
     """RAG 검색 결과 텍스트 (전략/계획 수립 시 프롬프트에 주입)"""
+
+    node_graph: dict[str, Any]
+    """프론트엔드 DAG 시각화를 위한 노드 그래프 데이터 (nodes, edges)"""

--- a/src/state/messages.py
+++ b/src/state/messages.py
@@ -7,6 +7,70 @@ from typing import Any
 from typing_extensions import TypedDict
 
 
+class NodeEdge(TypedDict):
+    """노드 간 데이터 흐름 엣지
+
+    Attributes:
+        from_node: 소스 노드 ID
+        to_node: 타겟 노드 ID
+        data_key: 전달 데이터 키 (예: analysis_strategy, task_result)
+        data_summary: 전달 데이터 요약 (300자 이내)
+    """
+
+    from_node: str
+    """소스 노드 ID"""
+
+    to_node: str
+    """타겟 노드 ID"""
+
+    data_key: str
+    """전달 데이터 키"""
+
+    data_summary: str
+    """전달 데이터 요약"""
+
+
+class NodeRelation(TypedDict):
+    """노드 관계 및 레이아웃 정보
+
+    프론트엔드 DAG 시각화를 위한 노드 위치, 상태, 연결 정보
+
+    Attributes:
+        id: 노드 고유 ID (예: strategy, step_0, report)
+        label: 표시명 (예: 레지스트리 분석)
+        type: 노드 유형 (strategy | planning | execution | report)
+        row: 그래프 Y축 위치 (0부터, 위에서 아래)
+        col: 같은 row 내 X축 위치 (병렬 노드 대비)
+        status: 노드 상태 (pending | running | success | error | skip)
+        inputs: 이 노드로 들어오는 엣지 목록
+        outputs: 이 노드에서 나가는 엣지 목록
+    """
+
+    id: str
+    """노드 고유 ID"""
+
+    label: str
+    """표시명"""
+
+    type: str
+    """노드 유형"""
+
+    row: int
+    """그래프 Y축 위치"""
+
+    col: int
+    """같은 row 내 X축 위치"""
+
+    status: str
+    """노드 상태"""
+
+    inputs: list[NodeEdge]
+    """이 노드로 들어오는 엣지 목록"""
+
+    outputs: list[NodeEdge]
+    """이 노드에서 나가는 엣지 목록"""
+
+
 class TaskAssignment(TypedDict):
     """Manager가 Sub-Agent에 전달하는 작업 할당
 


### PR DESCRIPTION
## 연관된 이슈
Close #39 

## Summary
- 프론트엔드 DAG 시각화를 위한 노드 간 연결/위치/상태 데이터 자동 생성
- 각 오케스트레이션 단계(strategy → planning → execution → report) 완료 시 `node_graph` 자동 갱신 
- follow-up step 동적 추가 시 노드/엣지/report row 자동 조정

## Description

### 변경 내용 
- `src/state/messages.py` - `NodeRelation`, `NodeEdge` TypedDict 타입 추가
- `src/state/manager.py` - `ManagerState`에 `node_graph` 필드 추가
- `src/node_graph.py` - 그래프 빌드/업데이트 함수 모듈
- `src/agents/manager/graph.py` - 각 단계 함수에서 `node_graph` 자동 갱신 통합

### 프론트엔드 전달 흐름
백엔드(FastAPI) → WebSocket `send_event` → 프론트엔드 
- 각 단계 완료 시 WebSocket 이벤트에 `node_graph` 필드가 포함되어 전송됨
- `GET /api/analysis/{case_id}/graph` 엔드포인트로 현재 그래프 직접 조회 가능 
- 백엔드 연동은 `2026-cnu-capstone/backend` 레포의 별도 PR에서 처리 

### 프론트엔드 연동 가이드

API 응답(`get_graph_response()`) 형식:

```json 
{ 
"nodes": [
    {"id": "strategy","label": "분석 전략","type": "strategy","row": 0, "col": 0, "status": "success"}, 
    {"id": "planning","label": "실행 계획","type": "planning","row": 1, "col": 0, "status": "success"}, 
    {"id": "step_0","label": "레지스트리 분석", "type": "execution", "row": 2, "col": 0, "status": "success"},
    {"id": "step_1","label": "이벤트로그 분석", "type": "execution", "row": 3, "col": 0, "status": "error"}, 
    {"id": "report","label": "보고서 생성", "type": "report","row": 4, "col": 0, "status": "pending"} 
],
"edges": [
    {"from_node": "strategy", "to_node": "planning", "data_key": "analysis_strategy", "data_summary": "레지스트리, 이벤트로그 
    분석"}, 
    {"from_node": "planning", "to_node": "step_0", "data_key": "plan_step", "data_summary": ""},
    {"from_node": "step_0", "to_node": "step_1", "data_key": "task_result", "data_summary": "Run 키에서 악성코드 발견"},
    {"from_node": "step_0", "to_node": "report", "data_key": "task_results","data_summary": "Run 키에서 악성코드 발견"},
    {"from_node": "step_1", "to_node": "report", "data_key": "task_results","data_summary": ""} 
    ] 
} 
``` 

#### nodes 배열 

| 필드 | 의미 | 프론트엔드 사용 방법 |
|------|------|---------------------| 
| `id` | 노드 고유 식별자 | 엣지 연결 매칭 키 |
| `label` | 표시명 | 노드 내부 텍스트 렌더링 |
| `type` | 노드 종류 (`strategy` / `planning` / `execution` / `report`) | 색상·아이콘 구분 |
| `row` | 세로 위치 (0부터) | Y좌표 = `row × 간격` |
| `col` | 가로 위치 (0부터) | X좌표 = `col × 간격` (현재 전부 0, 병렬 노드 대비 예약) | 
| `status` | 노드 상태 (`pending` / `running` / `success` / `error` / `skip`) | 노드 스타일 결정 |

#### edges 배열 

| 필드 | 의미 | 프론트엔드 사용 방법 |
|------|------|---------------------| 
| `from_node` | 시작 노드 `id` | 화살표 출발점 |
| `to_node` | 도착 노드 `id` | 화살표 도착점 |
| `data_key` | 전달 데이터 종류 | 툴팁 표시 | 
| `data_summary` | 데이터 요약 (최대 300자) | 엣지 라벨 또는 호버 시 표시 |
