### PR TITLE
[#40] 노드별 DFXML fragment 실시간 생성 및 관리

### DIFF
--- a/scripts/run_agent.py
+++ b/scripts/run_agent.py
@@ -678,17 +678,23 @@ async def main() -> None:
 
             try:
                 from database.engine import get_session
+                from database.repository import create_case
 
-                async with get_session(db_engine) as session:
-                    case = await create_case(
-                        session,
-                        user_prompt=user_input,
-                        disk_image_path=image_path,
-                        disk_image_format=image_format,
-                    )
-                print(f"  {DIM}케이스 #{case.id} 생성{RESET}")
+                case_id = None
+                try:
+                    async with get_session(db_engine) as session:
+                        case = await create_case(
+                            session,
+                            user_prompt=user_input,
+                            disk_image_path=image_path,
+                            disk_image_format=image_format,
+                        )
+                        case_id = case.id
+                    print(f"  {DIM}케이스 #{case_id} 생성{RESET}")
+                except Exception as exc:
+                    print(f"  {YELLOW}케이스 DB 저장 실패: {exc}{RESET}")
 
-                persistent_cb = PersistentExecutionCallback(event_store, case.id)
+                persistent_cb = PersistentExecutionCallback(event_store, case_id) if case_id else None
 
                 state = create_manager_state(
                     user_message=user_input,
@@ -696,6 +702,8 @@ async def main() -> None:
                     disk_image_format=image_format,
                     system_profile=system_profile,
                 )
+                if case_id:
+                    state["case_id"] = case_id
 
                 cache_key = _cache_key(image_path, user_input) if args.use_cache else ""
 
@@ -750,7 +758,7 @@ async def main() -> None:
 
                     exec_start = time.time()
                     cb = ConsoleExecutionCallback(persistent_cb=persistent_cb)
-                    state = await run_execution(state, llm, mcp, callback=cb, rag_service=rag_service, light_llm=light_llm)
+                    state = await run_execution(state, llm, mcp, callback=cb, rag_service=rag_service, light_llm=light_llm, db_engine=db_engine)
 
                     task_results = state.get("task_results", [])
                     accumulated_results.extend(task_results)

--- a/src/agents/manager/graph.py
+++ b/src/agents/manager/graph.py
@@ -30,6 +30,7 @@ from node_graph import (
     update_step_started,
     update_strategy_done,
 )
+from prompts.report import build_dfxml_prompt
 from rag.service import RAGService
 from state.manager import ManagerState
 from state.messages import TaskAssignment, TaskResult
@@ -222,17 +223,6 @@ async def run_execution(
             if sub_result.get("result"):
                 results.append(sub_result["result"])
                 context = sub_result["result"].get("output", "")[:500]
-
-                artifact_data = sub_result.get("dfxml_fragment", "")
-                if artifact_data:
-                    evidence_repo.append({
-                        "task_id": task["task_id"],
-                        "agent_name": agent_name,
-                        "server_name": server_name,
-                        "artifact": artifact_data,
-                        "format": "dfxml",
-                        "timestamp": datetime.now(timezone.utc).isoformat(),
-                    })
             else:
                 error_result: TaskResult = {
                     "task_id": task["task_id"],
@@ -261,10 +251,43 @@ async def run_execution(
             output_summary=last_result.get("output", ""),
         )
 
+        dfxml_frag = ""
+        if last_result.get("status") == "success":
+            dfxml_llm = light_llm or llm
+            try:
+                dfxml_resp = await dfxml_llm.chat(
+                    messages=[{
+                        "role": "user",
+                        "content": "이 단계의 결과를 DFXML로 변환해주세요.",
+                    }],
+                    tools=None,
+                    system=build_dfxml_prompt([last_result]),
+                )
+                dfxml_frag = (
+                    dfxml_resp.content
+                    if isinstance(dfxml_resp.content, str) else ""
+                )
+            except Exception as exc:
+                logger.warning(
+                    "dfxml_fragment_generation_failed",
+                    task_id=task["task_id"],
+                    error=str(exc),
+                )
+
+            if dfxml_frag:
+                evidence_repo.append({
+                    "task_id": task["task_id"],
+                    "agent_name": agent_name,
+                    "server_name": server_name,
+                    "artifact": dfxml_frag,
+                    "format": "dfxml",
+                    "timestamp": datetime.now(timezone.utc).isoformat(),
+                })
+
         if callback:
             step_result_for_cb = dict(last_result)
             if evidence_repo and evidence_repo[-1].get("task_id") == task["task_id"]:
-                step_result_for_cb["artifact"] = evidence_repo[-1]["artifact"]
+                step_result_for_cb["dfxml_fragment"] = evidence_repo[-1]["artifact"]
             callback.on_step_done(i, total, step, agent_name, step_result_for_cb)
 
         follow_up = last_result.get("follow_up")
@@ -325,7 +348,7 @@ async def run_report(
     state: ManagerState,
     llm: BaseLLMProvider,
     light_llm: BaseLLMProvider | None = None,
-) -> dict[str, str]:
+) -> dict[str, Any]:
     """Report Agent 실행
 
     Args:
@@ -334,7 +357,7 @@ async def run_report(
         light_llm: 경량 LLM 프로바이더 (DFXML 등 단순 작업용)
 
     Returns:
-        {"summary": ..., "report": ..., "dfxml": ...}
+        summary, report, dfxml(통합), dfxml_fragments(step별) 포함 딕셔너리
     """
     task_results = state.get("task_results", [])
     case_description = ""
@@ -359,7 +382,11 @@ async def run_report(
         "summary": result.get("summary", ""),
         "report": result.get("report", ""),
         "dfxml": result.get("dfxml", ""),
+<<<<<<< HEAD
         "node_graph": graph,
+=======
+        "dfxml_fragments": result.get("dfxml_fragments", {}),
+>>>>>>> ecec267 (feat: generate DFXML fragments per step during execution)
     }
 
 

--- a/src/agents/manager/graph.py
+++ b/src/agents/manager/graph.py
@@ -18,6 +18,8 @@ from agents.manager.nodes import (
 )
 from agents.report.graph import build_report_graph, create_report_state
 from constants import EXECUTION_STEP_DELAY, MAX_FOLLOWUP_STEPS
+from database.engine import get_session
+from database.repository import create_agent_run, create_step_result, update_agent_run
 from llm_provider.base import BaseLLMProvider
 from mcp_client.client import MCPClientManager
 from node_graph import (
@@ -116,6 +118,7 @@ async def run_execution(
     registry: AgentRegistry | None = None,
     rag_service: RAGService | None = None,
     light_llm: BaseLLMProvider | None = None,
+    db_engine: Any | None = None,
 ) -> ManagerState:
     """Sub-Agent 실행 단계
 
@@ -131,6 +134,7 @@ async def run_execution(
         registry: Sub-Agent 레지스트리 (None이면 기본 레지스트리 사용)
         rag_service: RAG 서비스 (None이면 결과 저장 건너뜀)
         light_llm: 요약 등 단순 작업에 사용할 경량 LLM (None이면 메인 LLM 사용)
+        db_engine: DB 엔진 (None이면 step 결과 DB 저장 건너뜀)
 
     Returns:
         task_results가 채워진 상태
@@ -141,6 +145,17 @@ async def run_execution(
 
     if registry is None:
         registry = create_default_registry(light_llm=light_llm)
+
+    agent_run_id: int | None = None
+    if db_engine and state.get("case_id"):
+        try:
+            async with get_session(db_engine) as session:
+                agent_run = await create_agent_run(
+                    session, state["case_id"], "execution"
+                )
+                agent_run_id = agent_run.id
+        except Exception as exc:
+            logger.warning("agent_run_create_failed", error=str(exc))
 
     plan_steps = list(state.get("plan_steps", []))
     disk_image_path = state.get("disk_image_path") or ""
@@ -284,6 +299,25 @@ async def run_execution(
                     "timestamp": datetime.now(timezone.utc).isoformat(),
                 })
 
+        if db_engine and agent_run_id:
+            try:
+                async with get_session(db_engine) as session:
+                    await create_step_result(
+                        session,
+                        agent_run_id=agent_run_id,
+                        step_index=i,
+                        tool_name=last_result.get("agent_name", ""),
+                        output_summary=last_result.get("output", "")[:500],
+                        raw_output=last_result.get("output", ""),
+                        dfxml_fragment=dfxml_frag if last_result.get("status") == "success" else "",
+                    )
+            except Exception as exc:
+                logger.warning(
+                    "step_result_save_failed",
+                    step_index=i,
+                    error=str(exc),
+                )
+
         if callback:
             step_result_for_cb = dict(last_result)
             if evidence_repo and evidence_repo[-1].get("task_id") == task["task_id"]:
@@ -314,6 +348,18 @@ async def run_execution(
             )
 
         i += 1
+
+    if db_engine and agent_run_id:
+        has_error = any(r.get("status") == "error" for r in results)
+        try:
+            async with get_session(db_engine) as session:
+                await update_agent_run(
+                    session,
+                    agent_run_id,
+                    status="error" if has_error else "success",
+                )
+        except Exception as exc:
+            logger.warning("agent_run_update_failed", error=str(exc))
 
     if rag_service and state.get("case_id"):
         results_summary = "\n".join(

--- a/src/agents/report/graph.py
+++ b/src/agents/report/graph.py
@@ -34,7 +34,10 @@ class ReportAgentState(TypedDict):
     """생성된 보고서 텍스트"""
 
     dfxml: str
-    """생성된 DFXML XML 문자열"""
+    """생성된 통합 DFXML XML 문자열"""
+
+    dfxml_fragments: dict[str, str]
+    """step별 개별 DFXML 프래그먼트 {task_id: dfxml_xml}"""
 
 
 def build_report_graph(
@@ -89,4 +92,5 @@ def create_report_state(
         summary="",
         report="",
         dfxml="",
+        dfxml_fragments={},
     )

--- a/src/agents/report/nodes.py
+++ b/src/agents/report/nodes.py
@@ -6,12 +6,13 @@ from typing import Any
 
 import structlog
 
+from llm_provider.base import BaseLLMProvider
 from prompts.report import (
+    build_dfxml_merge_prompt,
     build_dfxml_prompt,
     build_report_prompt,
     build_summary_prompt,
 )
-from llm_provider.base import BaseLLMProvider
 
 logger = structlog.get_logger()
 
@@ -89,28 +90,60 @@ async def dfxml_node(
 ) -> dict[str, Any]:
     """분석 결과를 DFXML 스키마로 변환
 
-    summary_node의 요약 결과를 기반으로 DFXML을 일괄 생성.
-    per-agent DFXML 프래그먼트 생성이 제거되었으므로
-    항상 요약 또는 task_results에서 직접 변환.
+    run_execution에서 step별로 생성된 DFXML 프래그먼트를
+    evidence_repository에서 수집하여 통합 DFXML로 병합.
+    프래그먼트가 없으면 task_results 기반으로 폴백 생성.
 
     Args:
-        state: Report Agent 상태 (task_results, summary 포함)
+        state: Report Agent 상태 (task_results, evidence_repository 포함)
         llm: LLM 프로바이더
     """
-    summary = state.get("summary", "")
+    task_results = state.get("task_results", [])
+    evidence_repo = state.get("evidence_repository", [])
 
-    if summary:
-        task_results = [{"task_id": "summary", "agent_name": "summary", "status": "success", "output": summary}]
+    dfxml_fragments: dict[str, str] = {
+        e["task_id"]: e["artifact"]
+        for e in evidence_repo
+        if e.get("artifact") and e.get("task_id")
+    }
+
+    logger.info("dfxml_fragments_collected", total=len(dfxml_fragments))
+
+    fragment_list = list(dfxml_fragments.values())
+    if len(fragment_list) > 1:
+        response = await llm.chat(
+            messages=[
+                {
+                    "role": "user",
+                    "content": "DFXML 프래그먼트를 병합해주세요.",
+                },
+            ],
+            tools=None,
+            system=build_dfxml_merge_prompt(fragment_list),
+        )
+        merged_dfxml = (
+            response.content if isinstance(response.content, str) else ""
+        )
+    elif len(fragment_list) == 1:
+        merged_dfxml = fragment_list[0]
     else:
-        task_results = state.get("task_results", [])
+        response = await llm.chat(
+            messages=[
+                {
+                    "role": "user",
+                    "content": "분석 결과를 DFXML로 변환해주세요.",
+                },
+            ],
+            tools=None,
+            system=build_dfxml_prompt(task_results),
+        )
+        merged_dfxml = (
+            response.content if isinstance(response.content, str) else ""
+        )
 
-    response = await llm.chat(
-        messages=[{"role": "user", "content": "분석 결과를 DFXML로 변환해주세요."}],
-        tools=None,
-        system=build_dfxml_prompt(task_results),
-    )
+    logger.info("dfxml_merged", length=len(merged_dfxml))
 
-    dfxml = response.content if isinstance(response.content, str) else ""
-    logger.info("dfxml_generated", length=len(dfxml))
-
-    return {"dfxml": dfxml}
+    return {
+        "dfxml": merged_dfxml,
+        "dfxml_fragments": dfxml_fragments,
+    }

--- a/src/database/models.py
+++ b/src/database/models.py
@@ -107,6 +107,7 @@ class StepResult(Base):
     tool_name: Mapped[str] = mapped_column(String(200), nullable=False)
     output_summary: Mapped[str] = mapped_column(Text, nullable=False, default="")
     raw_output: Mapped[str] = mapped_column(Text, nullable=False, default="")
+    dfxml_fragment: Mapped[str] = mapped_column(Text, nullable=False, default="")
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now()
     )

--- a/src/database/repository.py
+++ b/src/database/repository.py
@@ -122,6 +122,7 @@ async def create_step_result(
     tool_name: str,
     output_summary: str,
     raw_output: str = "",
+    dfxml_fragment: str = "",
 ) -> StepResult:
     """단계별 실행 결과 저장
 
@@ -132,6 +133,7 @@ async def create_step_result(
         tool_name: 사용된 MCP 도구 이름
         output_summary: 요약된 출력
         raw_output: 원본 전체 출력
+        dfxml_fragment: 해당 step의 DFXML 프래그먼트
 
     Returns:
         생성된 StepResult 인스턴스
@@ -142,6 +144,7 @@ async def create_step_result(
         tool_name=tool_name,
         output_summary=output_summary,
         raw_output=raw_output,
+        dfxml_fragment=dfxml_fragment,
     )
     session.add(step_result)
     await session.commit()
@@ -252,3 +255,29 @@ async def get_events_by_type(
     )
     result = await session.execute(stmt)
     return list(result.scalars().all())
+
+
+async def get_dfxml_fragment(
+    session: AsyncSession,
+    agent_run_id: int,
+    step_index: int,
+) -> str | None:
+    """특정 step의 DFXML 프래그먼트 조회
+
+    Args:
+        session: 비동기 DB 세션
+        agent_run_id: AgentRun ID
+        step_index: 조회할 step 인덱스
+
+    Returns:
+        DFXML 프래그먼트 문자열 또는 None
+    """
+    result = await session.execute(
+        select(StepResult.dfxml_fragment)
+        .where(
+            StepResult.agent_run_id == agent_run_id,
+            StepResult.step_index == step_index,
+        )
+    )
+    row = result.scalar_one_or_none()
+    return row if row else None


### PR DESCRIPTION
## 연관된 이슈
Close #40 

## Summary
- 각 step 실행 완료 시 즉시 DFXML fragment를 생성하여 프론트엔드에 실시간 전달
- Report 단계에서는 기존 fragment를 병합만 수행 (추가 LLM 호출 없음)

## Description
### 변경 내용 
- `src/agents/report/graph.py` - ReportAgentState에 dfxml_fragments 필드 추가
- `src/agents/report/nodes.py` - dfxml_node가 evidence_repository에서 fragment 수집 후 병합만 수행
- `src/agents/manager/graph.py` - run_execution에서 step 성공 시 light_llm으로 DFXML fragment 즉시 생성, AgentRun/StepResult DB
저장, run_report 반환값에 dfxml_fragments 포함
- `src/database/models.py` - StepResult.dfxml_fragment 컬럼 추가
- `src/database/repository.py` - create_step_result에 dfxml_fragment 파라미터, get_dfxml_fragment() 조회 함수 추가
- `scripts/run_agent.py` - 케이스 DB 저장 + run_execution에 db_engine 전달

### 실시간 전달 흐름
``` 
step 실행 완료
→ light_llm으로 DFXML fragment 생성 
→ evidence_repository에 저장
→ callback.on_step_done()에 dfxml_fragment 포함 
→ WebSocket step_completed 이벤트로 프론트엔드에 실시간 전달
``` 

### 프론트엔드 수신 예시
`step_completed` WebSocket 이벤트:
```json 
{ 
    "type": "step_completed", 
    "step_index": 0,
    "step_name": "레지스트리 분석", 
    "status": "success",
    "output": "Run 키에서 악성코드 발견...",
    "dfxml_fragment": "<dfxml><fileobject><filename>NTUSER.DAT</filename>...</fileobject></dfxml>"
} 
``` 

`report_ready` 이벤트에는 통합본 + 전체 fragments:
```json 
{ 
    "dfxml": "<dfxml>통합본</dfxml>", 
    "dfxml_fragments": {
        "t1": "<dfxml>레지스트리 분석</dfxml>", 
        "t2": "<dfxml>이벤트로그 분석</dfxml>"
    } 
} 
``` 