### PR TITLE
[#51] Oracle Cloud 공유 DB 인프라 설정

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -1,0 +1,101 @@
+# Forensic AI · 공유 DB 사용 가이드
+
+> **DB 서버는 Oracle Cloud에 24시간 운영 중입니다.**  
+> 팀원 누구나 아래 접속 정보만 설정하면 바로 사용할 수 있습니다.  
+> 별도로 Docker를 설치하거나 실행할 필요 없습니다.
+
+---
+
+## 팀원 설정 (이것만 하면 됩니다)
+
+`agent/.env` 파일을 열고 `DATABASE_URL`을 아래로 설정하세요.
+
+```
+DATABASE_URL=postgresql+asyncpg://forensic_ai:forensic_ai@168.107.39.168:5432/forensic_ai
+```
+
+---
+
+## DB 접속 정보
+
+| 항목 | 값 |
+|------|-----|
+| Host | `168.107.39.168` |
+| Port | `5432` |
+| Database | `forensic_ai` |
+| User | `forensic_ai` |
+| Password | `forensic_ai` |
+
+---
+
+## DB 테이블 및 데이터 확인 방법
+
+### 방법 1 — pgAdmin 웹 UI (가장 쉬움)
+
+브라우저에서 접속: **http://168.107.39.168:5050**
+
+| 항목 | 값 |
+|------|-----|
+| 이메일 | `admin@forensic.ai` |
+| 비밀번호 | `forensic_ai` |
+
+**처음 접속 시 서버 등록 (1회만):**
+1. 왼쪽 `Servers` 우클릭 → `Register` → `Server`
+2. **일반** 탭: 이름 → `forensic_ai`
+3. **연결** 탭:
+   - 호스트: `forensic_ai_db`
+   - 포트: `5432`
+   - 데이터베이스: `forensic_ai`
+   - 사용자명: `forensic_ai`
+   - 비밀번호: `forensic_ai`
+4. 저장
+
+등록 후 `forensic_ai` → `Databases` → `forensic_ai` → `Schemas` → `Tables` 에서 테이블과 데이터를 볼 수 있습니다.
+
+---
+
+### 방법 2 — Python으로 빠른 확인
+
+```python
+import asyncio, asyncpg
+
+async def check():
+    conn = await asyncpg.connect(
+        "postgresql://forensic_ai:forensic_ai@168.107.39.168:5432/forensic_ai"
+    )
+    rows = await conn.fetch("SELECT * FROM cases ORDER BY created_at DESC LIMIT 10")
+    for r in rows:
+        print(r)
+    await conn.close()
+
+asyncio.run(check())
+```
+
+---
+
+## 테이블 목록 (v2 스키마)
+
+```
+cases                   포렌식 케이스 (루트)
+├── analysis_sessions   분석 세션
+│   └── plan_steps      분석 계획 단계
+│       └── agent_run   Sub-Agent 실행 단위
+│           └── task_results    실행 결과
+│               └── dfxml_fragments   DFXML 단편
+├── reports             최종 보고서
+├── workflow_nodes      React Flow 노드 위치
+├── workflow_edges      React Flow 엣지
+└── case_embedding      pgvector RAG 임베딩
+```
+
+---
+
+## 파일 구조 (참고용)
+
+```
+agent/
+├── docker-compose.yml   # 서버에서 실행 중인 Docker 설정
+├── db/
+│   └── init.sql         # v2 스키마 SQL (테이블 10개)
+└── DOCKER.md            # 이 파일
+```

--- a/db/init.sql
+++ b/db/init.sql
@@ -1,0 +1,196 @@
+-- Forensic AI · 통합 DB 스키마 v2
+-- PostgreSQL 16 + pgvector
+
+CREATE EXTENSION IF NOT EXISTS vector;
+
+-- updated_at 자동 갱신 트리거 함수
+CREATE OR REPLACE FUNCTION update_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- ─────────────────────────────────────────
+-- cases  (루트 테이블)
+-- ─────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS cases (
+  id               VARCHAR(36)   PRIMARY KEY DEFAULT gen_random_uuid()::text,
+  title            VARCHAR(255)  NOT NULL,
+  description      TEXT,
+  user_prompt      TEXT,
+  disk_image_path  VARCHAR(1024),
+  analyst          VARCHAR(64),
+  status           VARCHAR(20)   NOT NULL DEFAULT 'open',
+  created_at       TIMESTAMPTZ   NOT NULL DEFAULT NOW(),
+  updated_at       TIMESTAMPTZ   NOT NULL DEFAULT NOW()
+);
+
+CREATE TRIGGER cases_updated_at
+  BEFORE UPDATE ON cases
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at();
+
+-- ─────────────────────────────────────────
+-- analysis_sessions  (cases 1:N)
+-- ─────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS analysis_sessions (
+  id              SERIAL        PRIMARY KEY,
+  case_id         VARCHAR(36)   NOT NULL REFERENCES cases(id) ON DELETE CASCADE,
+  phase           VARCHAR(20)   NOT NULL,   -- strategy|plan|execute|report
+  system_profile  TEXT,
+  strategy        TEXT,
+  plan_text       TEXT,
+  result_summary  TEXT,
+  created_at      TIMESTAMPTZ   NOT NULL DEFAULT NOW(),
+  updated_at      TIMESTAMPTZ   NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX ON analysis_sessions(case_id);
+
+CREATE TRIGGER analysis_sessions_updated_at
+  BEFORE UPDATE ON analysis_sessions
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at();
+
+-- ─────────────────────────────────────────
+-- plan_steps  (analysis_sessions 1:N)
+-- ─────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS plan_steps (
+  id           SERIAL        PRIMARY KEY,
+  session_id   INTEGER       NOT NULL REFERENCES analysis_sessions(id) ON DELETE CASCADE,
+  case_id      VARCHAR(36)   NOT NULL REFERENCES cases(id),
+  step_index   INTEGER       NOT NULL,
+  mcp_server   VARCHAR(64),
+  purpose      TEXT,
+  hints        TEXT,
+  artifacts    JSONB,
+  is_followup  BOOLEAN       NOT NULL DEFAULT FALSE,
+  created_at   TIMESTAMPTZ   NOT NULL DEFAULT NOW(),
+  UNIQUE(session_id, step_index)
+);
+
+CREATE INDEX ON plan_steps(session_id);
+CREATE INDEX ON plan_steps(case_id);
+
+-- ─────────────────────────────────────────
+-- agent_run  (plan_steps 1:N)
+-- ─────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS agent_run (
+  id            SERIAL        PRIMARY KEY,
+  session_id    INTEGER       NOT NULL REFERENCES analysis_sessions(id) ON DELETE CASCADE,
+  plan_step_id  INTEGER       NOT NULL REFERENCES plan_steps(id) ON DELETE CASCADE,
+  agent_name    VARCHAR(64)   NOT NULL,
+  tool          VARCHAR(128),
+  status        VARCHAR(20)   NOT NULL DEFAULT 'running',  -- running|success|error|partial|skip
+  plan_round    INTEGER       NOT NULL DEFAULT 1,
+  started_at    TIMESTAMPTZ   NOT NULL DEFAULT NOW(),
+  finished_at   TIMESTAMPTZ
+);
+
+CREATE INDEX ON agent_run(session_id);
+CREATE INDEX ON agent_run(plan_step_id);
+
+-- ─────────────────────────────────────────
+-- task_results  (agent_run 1:N)
+-- ─────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS task_results (
+  id              SERIAL        PRIMARY KEY,
+  agent_run_id    INTEGER       NOT NULL REFERENCES agent_run(id) ON DELETE CASCADE,
+  case_id         VARCHAR(36)   NOT NULL REFERENCES cases(id),
+  task_id         VARCHAR(36)   NOT NULL,
+  status          VARCHAR(20)   NOT NULL,  -- running|success|error|partial|skip
+  content         TEXT,
+  output          TEXT,
+  raw_output_ref  VARCHAR(1024),
+  elapsed_ms      INTEGER,
+  artifacts       JSONB,
+  started_at      TIMESTAMPTZ   NOT NULL DEFAULT NOW(),
+  completed_at    TIMESTAMPTZ,
+  created_at      TIMESTAMPTZ   NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX ON task_results(agent_run_id);
+CREATE INDEX ON task_results(case_id);
+
+-- ─────────────────────────────────────────
+-- dfxml_fragments  (task_results 1:N)
+-- ─────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS dfxml_fragments (
+  id              SERIAL       PRIMARY KEY,
+  task_result_id  INTEGER      NOT NULL REFERENCES task_results(id) ON DELETE CASCADE,
+  agent_name      VARCHAR(64),
+  dfxml_fragment  TEXT         NOT NULL,
+  created_at      TIMESTAMPTZ  NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX ON dfxml_fragments(task_result_id);
+
+-- ─────────────────────────────────────────
+-- reports  (cases 1:N)
+-- ─────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS reports (
+  id           SERIAL       PRIMARY KEY,
+  case_id      VARCHAR(36)  NOT NULL REFERENCES cases(id) ON DELETE CASCADE,
+  summary      TEXT,
+  report_text  TEXT,
+  dfxml        TEXT,
+  status       VARCHAR(20)  NOT NULL DEFAULT 'draft',  -- draft|final|archived
+  created_at   TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+  updated_at   TIMESTAMPTZ  NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX ON reports(case_id);
+
+CREATE TRIGGER reports_updated_at
+  BEFORE UPDATE ON reports
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at();
+
+-- ─────────────────────────────────────────
+-- workflow_nodes  (cases 1:N · React Flow 캔버스)
+-- ─────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS workflow_nodes (
+  id          SERIAL       PRIMARY KEY,
+  case_id     VARCHAR(36)  NOT NULL REFERENCES cases(id) ON DELETE CASCADE,
+  x           DOUBLE PRECISION NOT NULL,
+  y           DOUBLE PRECISION NOT NULL,
+  updated_at  TIMESTAMPTZ  NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX ON workflow_nodes(case_id);
+
+CREATE TRIGGER workflow_nodes_updated_at
+  BEFORE UPDATE ON workflow_nodes
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at();
+
+-- ─────────────────────────────────────────
+-- workflow_edges  (cases 1:N · React Flow 캔버스)
+-- ─────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS workflow_edges (
+  id           SERIAL       PRIMARY KEY,
+  case_id      VARCHAR(36)  NOT NULL REFERENCES cases(id) ON DELETE CASCADE,
+  edge_id      VARCHAR(64)  NOT NULL,
+  source_node  VARCHAR(64)  NOT NULL,
+  target_node  VARCHAR(64)  NOT NULL,
+  updated_at   TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+  UNIQUE(case_id, edge_id)
+);
+
+CREATE INDEX ON workflow_edges(case_id);
+
+CREATE TRIGGER workflow_edges_updated_at
+  BEFORE UPDATE ON workflow_edges
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at();
+
+-- ─────────────────────────────────────────
+-- case_embedding  (pgvector RAG)
+-- ─────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS case_embedding (
+  id         SERIAL       PRIMARY KEY,
+  case_id    VARCHAR(36)  REFERENCES cases(id) ON DELETE SET NULL,
+  phase      VARCHAR(20)  NOT NULL,
+  content    TEXT         NOT NULL,
+  embedding  VECTOR(1024) NOT NULL,
+  created_at TIMESTAMPTZ  NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX ON case_embedding USING ivfflat (embedding vector_cosine_ops) WITH (lists = 100);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,35 @@
+services:
+  db:
+    image: pgvector/pgvector:pg16
+    container_name: forensic_ai_db
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: forensic_ai
+      POSTGRES_USER: forensic_ai
+      POSTGRES_PASSWORD: forensic_ai
+    ports:
+      - "5432:5432"
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+      - ./db/init.sql:/docker-entrypoint-initdb.d/10_init.sql
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U forensic_ai -d forensic_ai"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  pgadmin:
+    image: dpage/pgadmin4:8
+    container_name: forensic_ai_pgadmin
+    restart: unless-stopped
+    environment:
+      PGADMIN_DEFAULT_EMAIL: admin@forensic.ai
+      PGADMIN_DEFAULT_PASSWORD: forensic_ai
+    ports:
+      - "5050:80"
+    depends_on:
+      db:
+        condition: service_healthy
+
+volumes:
+  pgdata:


### PR DESCRIPTION
## Summary

Oracle Cloud에 24시간 운영되는 팀 공유 PostgreSQL DB 인프라 추가

## Description

- `docker-compose.yml`: Oracle Cloud VM에서 실행 중인 PostgreSQL(pgvector) + pgAdmin 컨테이너 설정
- `db/init.sql`: v2 스키마 SQL (cases, analysis_sessions, plan_steps, agent_run, task_results, dfxml_fragments, reports, workflow_nodes, workflow_edges, case_embedding 총 10개 테이블)
- `DOCKER.md`: 팀원 DB 접속 및 사용 가이드

팀원은 `agent/.env`의 `DATABASE_URL`만 아래로 변경하면 별도 Docker 설치 없이 공유 DB 사용 가능합니다.

```
DATABASE_URL=postgresql+asyncpg://forensic_ai:forensic_ai@168.107.39.168:5432/forensic_ai
```

Closes #51